### PR TITLE
secified SDK version that works with template

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,7 +4,7 @@ This page provides some basic guidance on getting up and running with your first
 
 You'll need to install the following pre-requisites in order to build SAFE applications
 
-* The [.NET Core SDK 2.1](https://www.microsoft.com/net/download/).
+* The [.NET Core SDK 2.1.300](https://www.microsoft.com/net/download/dotnet-core/2.1). (you need version 2.1.300 to use the template)
 * [FAKE 5](https://fake.build/) installed as a [global tool](https://fake.build/fake-gettingstarted.html#Install-FAKE)
 * The [Yarn](https://yarnpkg.com/lang/en/docs/install/) package manager.
 * [Node 8.x](https://nodejs.org/en/download/) installed for the front end components.


### PR DESCRIPTION
the SAFE template did not work with the latest dotnet SDK. I had to install version 2.1.300 to make the template work.