### PR TITLE
Use absolute urls for prev and next page nav - references #72

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,7 +23,7 @@ extra:
     - type: 'globe'
       link: https://safe-stack.github.io/
 
-pages:
+nav:
 - Home: 'index.md'
 - Introduction: 'intro.md'
 - Quick Start: 'quickstart.md'

--- a/theme/partials/footer.html
+++ b/theme/partials/footer.html
@@ -10,7 +10,7 @@
 
         <!-- Link to previous page -->
         {% if page.previous_page %}
-          <a href="{{ page.previous_page.url }}"
+          <a href="/{{ page.previous_page.url }}"
               title="{{ page.previous_page.title }}"
               class="md-flex md-footer-nav__link md-footer-nav__link--prev"
               rel="prev">
@@ -32,7 +32,7 @@
 
         <!-- Link to next page -->
         {% if page.next_page %}
-          <a href="{{ page.next_page.url }}" title="{{ page.next_page.title }}"
+          <a href="/{{ page.next_page.url }}" title="{{ page.next_page.title }}"
               class="md-flex md-footer-nav__link md-footer-nav__link--next"
               rel="next">
             <div class="md-flex__cell md-flex__cell--stretch


### PR DESCRIPTION
Also change 'pages' to 'nav' in yml config, as mkdocs v1.0 says 'pages' are obsolete.

This fixes #72 on my box, @isaacabraham  - can you check if that works for you as well?
What version of mkdocs are you using?