### PR TITLE
Mention NPX in js-deps

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -6,7 +6,7 @@ You'll need to install the following pre-requisites in order to build SAFE appli
 
 * The [.NET Core SDK 2.1](https://www.microsoft.com/net/download/).
 * [FAKE 5](https://fake.build/) installed as a [global tool](https://fake.build/fake-gettingstarted.html#Install-FAKE) - recommended version is FAKE >= 5.10
-* The [Yarn](https://yarnpkg.com/lang/en/docs/install/) package manager.
+* The [Yarn](https://yarnpkg.com/lang/en/docs/install/) or [NPM](template-overview.md#js-deps) package manager. 
 * [Node 8.x](https://nodejs.org/en/download/) installed for the front end components.
 * If you're running on OSX or Linux, you'll also need to install [Mono](https://www.mono-project.com/docs/getting-started/install/).
 
@@ -28,7 +28,7 @@ You'll also want an IDE to create F# applications. We recommend one of the follo
 
 Congratulations - after a short delay, you'll be presented with a basic SAFE application running in your browser! The application will by default run in "development mode", which means it automatically watch your project for changes; whenever you save a file in the client project it will refresh the browser **automatically**; if you save a file in the server project it will also restart the server in the background.
 
-Take a look at the [template options](template-overview.md#template-options.md). There are several ways to customise the default application, such as server and client/server communication technologies.
+Take a look at the [template options](template-overview.md#template-options). There are several ways to customise the default application, such as server and client/server communication technologies.
 
 ## Troubleshooting
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,13 +4,13 @@ This page provides some basic guidance on getting up and running with your first
 
 You'll need to install the following pre-requisites in order to build SAFE applications
 
-* The [.NET Core SDK 2.1](https://www.microsoft.com/net/download/).
-* [FAKE 5](https://fake.build/) installed as a [global tool](https://fake.build/fake-gettingstarted.html#Install-FAKE) - recommended version is FAKE >= 5.10
-* A Javascript package manager, either
-	* [Yarn](https://yarnpkg.com/lang/en/docs/install/) - recommended version is Yarn >= 1.10.1, or
-	* [NPM](template-overview.md#js-deps)
-* [Node 8.x](https://nodejs.org/en/download/) installed for the front end components.
-* If you're running on OSX or Linux, you'll also need to install [Mono](https://www.mono-project.com/docs/getting-started/install/).
+* The [.NET Core SDK 2.1](https://www.microsoft.com/net/download/)
+* [FAKE 5](https://fake.build/) installed as a [global tool](https://fake.build/fake-gettingstarted.html#Install-FAKE) (recommended version >= 5.10)
+* A Javascript package manager, one of:
+	* [Yarn](https://yarnpkg.com/lang/en/docs/install/) (recommended version >= 1.10.1)
+	* [NPM](https://www.npmjs.com/) plus [required dependencies](template-overview.md#js-deps)
+* [Node 8.x](https://nodejs.org/en/download/) installed for the front end components
+* If you're running on OSX or Linux, you'll also need to install [Mono](https://www.mono-project.com/docs/getting-started/install/)
 
 ## Install an F# code editor
 

--- a/docs/template-overview.md
+++ b/docs/template-overview.md
@@ -100,4 +100,4 @@ Usage: `dotnet new SAFE --js-deps <package manager>`
 Where `<package manager>` is one of:
 
 * `yarn`: uses [Yarn](https://yarnpkg.com/) for JS package management  **(default)**.
-* `npm`: uses [NPM](https://www.npmjs.com/) for JS package management.
+* `npm`: uses [NPM](https://www.npmjs.com/) for JS package management. If you use NPM, you'll also need [NPX](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b) to run scripts.


### PR DESCRIPTION
https://github.com/SAFE-Stack/SAFE-template/pull/199 updates fable loader to 2.1, which makes use of javascript exclusively, but adds a dependency on NPX if NPM is used