### PR TITLE
Remove mono / full .net from prerequisites

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,19 +4,17 @@ This page provides some basic guidance on getting up and running with your first
 
 You'll need to install the following pre-requisites in order to build SAFE applications
 
-* The [.NET Core SDK 2.1](https://www.microsoft.com/net/download/)
-* [FAKE 5](https://fake.build/) installed as a [global tool](https://fake.build/fake-gettingstarted.html#Install-FAKE) (recommended version >= 5.10)
-* A Javascript package manager, one of:
-	* [Yarn](https://yarnpkg.com/lang/en/docs/install/) (recommended version >= 1.10.1)
-	* [NPM](https://www.npmjs.com/) plus [required dependencies](template-overview.md#js-deps)
-* [Node 8.x](https://nodejs.org/en/download/) installed for the front end components
-* If you're running on OSX or Linux, you'll also need to install [Mono](https://www.mono-project.com/docs/getting-started/install/)
+* [dotnet SDK](https://dotnet.microsoft.com/download) (>= 2.2)
+* [FAKE](https://fake.build/) (>= 5.12) installed as global tool (`dotnet tool install -g fake-cli`)
+* (optional) [Paket](https://fsprojects.github.io/Paket) (>= 5.196) installed as global tool (`dotnet tool install -g paket`)
+* [node.js](https://nodejs.org/) (>= 8.0)
+* [yarn](https://yarnpkg.com/) (>= 1.10.1) or [npm](https://www.npmjs.com/)
 
 ## Install an F# code editor
 
 You'll also want an IDE to create F# applications. We recommend one of the following great IDEs.
 
-* [VS Code](https://code.visualstudio.com/) + [Ionide](https://github.com/ionide/ionide-vscode-fsharp) extension
+* [VS Code](https://code.visualstudio.com/) + [Ionide](https://github.com/ionide/ionide-vscode-fsharp) extension (support for [Full Stack Debugging](feature-debugging.md))
 * [Visual Studio 2017](https://www.visualstudio.com/downloads/)
 * [Jetbrains Rider](https://www.jetbrains.com/rider/)
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -6,7 +6,7 @@ You'll need to install the following pre-requisites in order to build SAFE appli
 
 * [dotnet SDK](https://dotnet.microsoft.com/download) (>= 2.2)
 * [FAKE](https://fake.build/) (>= 5.12) installed as global tool (`dotnet tool install -g fake-cli`)
-* (optional) [Paket](https://fsprojects.github.io/Paket) (>= 5.196) installed as global tool (`dotnet tool install -g paket`)
+* (optional) [Paket](https://fsprojects.github.io/Paket) (>= 5.196), can also be installed as global tool (`dotnet tool install -g paket`)
 * [node.js](https://nodejs.org/) (>= 8.0)
 * [yarn](https://yarnpkg.com/) (>= 1.10.1) or [npm](https://www.npmjs.com/)
 


### PR DESCRIPTION
IMO we should drop requirement on full .NET / mono for legacy Paket and instead suggest installing (optionally) Paket as global dotnet tool.
Optionally, because as long as you don't need to manipulate dependencies, you can build fine with just using FAKE.
This is a temporary solution until we upgrade to .net core 3.0 and use local dotnet tools