### PR TITLE
Update pattern docs to match template help text

### DIFF
--- a/docs/template-overview.md
+++ b/docs/template-overview.md
@@ -78,7 +78,8 @@ Usage: `dotnet new SAFE --pattern <pattern model>`
 Where `<pattern model>` is one of:
 
 * `default`: use standard Elmish architecture with Commands **(default)**
-* `reaction`: use simple Elmish architecture without Commands + [Fable.Reaction](https://dbrattli.github.io/Reaction/) for reactive pattern
+* `streams`: use simple Elmish architecture without Commands + [Elmish.Streams](https://elmish-streams.readthedocs.io/) for reactive pattern
+* `reaction`: obsolete - use `streams` (Fable.Reaction rebranded to Elmish.Streams)
 
 ### Deploy
 


### PR DESCRIPTION
After https://github.com/SAFE-Stack/SAFE-template/pull/250, the docs should be updated to match what `dotnet new SAFE --help` prints (currently the `--pattern` docs are out of date).