### PR TITLE
Improve template-fake.

### DIFF
--- a/docs/template-fake.md
+++ b/docs/template-fake.md
@@ -2,17 +2,9 @@ The template uses [FAKE](https://fake.build/) to build the application.
 
 Generated FAKE script consist of two primary build targets, used for different purposes:
 
-## **"Build"** target
-
-This target is a standard build procedure, consisting of following steps:
-
-1. **InstallDotNetCore** - here, a required version of dotnet core is read from `global.json` file and if not yet installed, the script downloads and performs the installation of desired dotnet core SDK.
-1. **InstallClient** - in this step, either NPM or Yarn is invoked (based on which option was chosen when generating project) and it installs all Client dependencies defined in `package.json`. The step also performs `dotnet restore` to fetch NuGet-based packages used by front-end.
-1. **Build** - for server side `dotnet build` command is invoked, and for client side a special `dotnet-fable` CLI tool using `dotnet fable webpack` command with `-p` flag to compile Client project to a single JavaScript bundle file.
-
-*Note: Extra build steps will be included if you specified the [`--deploy docker`](template-docker.md) or [`--deploy azure`](template-appservice.md) flag when creating your project.*
-
 ## **"Run"** target
+
+Enter `fake build --target run` to build and run the app
 
 This target is used for development purposes, and provides a great live-reload experience. It consists of following steps:
 
@@ -22,3 +14,26 @@ This target is used for development purposes, and provides a great live-reload e
     1. `dotnet watch run` for Server side - compiles, runs Server and watches for changes in Server source files. Whenever a change in any source file is detected, Server is automatically stopped, recompiled and rerun in the background,
     1. `dotnet fable webpack-dev-server` for Client side - compiles Client to JavaScript and runs [Webpack dev-server](https://github.com/webpack/webpack-dev-server) - this in turn recompiles and reloads the client application upon any source file change in Client project,
     1. New process is started for `http://localhost:8080` to open the URL in default browser
+
+## **"Build"** target
+
+This target is a standard build procedure, consisting of following steps:
+
+1. **InstallDotNetCore** - here, a required version of dotnet core is read from `global.json` file and if not yet installed, the script downloads and performs the installation of desired dotnet core SDK.
+1. **InstallClient** - in this step, either NPM or Yarn is invoked (based on which option was chosen when generating project) and it installs all Client dependencies defined in `package.json`. The step also performs `dotnet restore` to fetch NuGet-based packages used by front-end.
+1. **Build** - for server side `dotnet build` command is invoked, and for client side a special `dotnet-fable` CLI tool using `dotnet fable webpack` command with `-p` flag to compile Client project to a single JavaScript bundle file. 
+
+*Note: Extra build steps will be included if you specified the [`--deploy docker`](template-docker.md) or [`--deploy azure`](template-appservice.md) flag when creating your project.*
+
+For specific buid parameters, go to one of the **Deployment Options** pages:
+
+* [`Deploy to Docker`](template-docker.md)
+* [`Registering with Azure`](template-azure-registration.md)
+    * [`Deploy to App Service`](template-appservice.md)
+* [`Registering with Google Cloud`](template-google-cloud.md)
+    * [`Deploy to Google Cloud AppEngine`](template-gcp-appengine.md)
+    * [`Deploy to Google Cloud Kubernetes Engine`](template-gcp-kubernetes.md)
+* [`Deploy to Heroku`](template-heroku.md)
+* [`Deploy to IIS`](template-iis.md)
+* [`Application Insights Integration`](template-azure-ai.md)
+

--- a/docs/template-fake.md
+++ b/docs/template-fake.md
@@ -25,15 +25,4 @@ This target is a standard build procedure, consisting of following steps:
 
 *Note: Extra build steps will be included if you specified the [`--deploy docker`](template-docker.md) or [`--deploy azure`](template-appservice.md) flag when creating your project.*
 
-For specific buid parameters, go to one of the **Deployment Options** pages:
-
-* [`Deploy to Docker`](template-docker.md)
-* [`Registering with Azure`](template-azure-registration.md)
-    * [`Deploy to App Service`](template-appservice.md)
-* [`Registering with Google Cloud`](template-google-cloud.md)
-    * [`Deploy to Google Cloud AppEngine`](template-gcp-appengine.md)
-    * [`Deploy to Google Cloud Kubernetes Engine`](template-gcp-kubernetes.md)
-* [`Deploy to Heroku`](template-heroku.md)
-* [`Deploy to IIS`](template-iis.md)
-* [`Application Insights Integration`](template-azure-ai.md)
-
+For specific build parameters, go to one of the **Deployment Options** pages in the menu.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,8 +34,8 @@ nav:
   - Learn about Fable : 'component-fable.md'
   - Learn about Elmish : 'component-elmish.md'
 - The SAFE Template:
-  - SAFE Template overview: 'template-overview.md'
-  - FAKE script: 'template-fake.md'
+  - Overview: 'template-overview.md'
+  - Run and Build the app: 'template-fake.md'
   - Deployment Options:
     - Deploy to Docker: 'template-docker.md'
     - Deploy to App Service: 'template-appservice.md'


### PR DESCRIPTION
Put Run first because users will usually want to make something before building it for deploy
Add Fake command line to build and run
Add link to Fake command to build and deploy
Rename  SAFE Template overview link to  Overview, because it's already below the Safe Template heading.
Rename  FAKE script  link  to Run and Build the app, which is more meaningful for someone looking for that information.