### PR TITLE
Update paket instruction

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -6,11 +6,11 @@ You'll need to install the following pre-requisites in order to build SAFE appli
 
 * The [.NET Core SDK 2.2](https://www.microsoft.com/net/download/)
 * [FAKE](https://fake.build/) (>= 5.12) installed as global tool (`dotnet tool install -g fake-cli`)
-* [Paket](https://fsprojects.github.io/Paket) (optional\*)
+* [Paket](https://fsprojects.github.io/Paket) installed as global tool (`dotnet tool install paket --add-source https://www.myget.org/F/paket-netcore-as-tool/api/v3/index.json -g`) (optional\*)
 * [node.js](https://nodejs.org/) (>= 8.0)
 * [yarn](https://yarnpkg.com/) (>= 1.10.1) or [npm](https://www.npmjs.com/)
 
-\* You don't need Paket if you just want to try out SAFE. However if you need to edit NuGet dependencies you can [read docs](https://fsprojects.github.io/Paket/getting-started.html) on how to get started with Paket.
+\* You don't need Paket if you just want to try out SAFE. However if you need to edit NuGet dependencies you can [read docs](https://fsprojects.github.io/Paket/getting-started.html) on how to get started with Paket. When installed as global tool you can invoke it via `paket` CLI
 
 ## Install an F# code editor
 


### PR DESCRIPTION
Related to: https://github.com/SAFE-Stack/SAFE-template/issues/106#issuecomment-527900054

I am not sure what is the correct way to setup paket as a global tool. The solution proposed here is the most straightforward but perhaps not the best.

I used https://github.com/enricosada/paket-netcore-testing-as-tool as a documentation reference.

I guess we can also, ask "paket team" to update their doc website to know what the recommended way to use/setup paket as a global tool?

cc @forki @enricosada @isaacabraham @theimowski 