### PR TITLE
Update deployment docs

### DIFF
--- a/docs/template-appservice.md
+++ b/docs/template-appservice.md
@@ -8,7 +8,7 @@ It comes in a number of pricing plans, including a free option and has options f
 
 ## Deployment Steps
 
-In order to deploy your SAFE application to the App Service, you must have first created an [Azure Account](template-azure-registration.md#creating-an-azure-account), selected a [Subscription ID](template-azure-registration.md#selecting-a-subscription) and created an associated [App Registration](template-azure-registration.md#creating-an-app-registration).
+In order to deploy your SAFE application to the App Service, you must have first created an [Azure Account](template-azure-registration.md#creating-an-azure-account), selected a [Subscription ID](template-azure-registration.md#selecting-a-subscription) and created an associated [App Registration](template-azure-registration.md#creating-an-app-registration), and have created your solution using the azure [deployment setting](template-overview.md#Deploy)
 
 ### Custom FAKE build tasks
 
@@ -31,6 +31,7 @@ Deploying your application through FAKE is relatively simple. Use the following 
 fake build --target appservice
     -e subscriptionId=<subId>
     -e clientId=<clientId>
+    -e tenantId=<tenantId>
     -e environment=<environment> (optional)
     -e location=<location>       (optional)
     -e pricingTier=<pricingTier> (optional)
@@ -38,7 +39,8 @@ fake build --target appservice
 where:
 
 * `subscriptionId` is an Azure Subscription ID.
-* `clientId` is the Application ID of an Azure App Registration.
+* `clientId` is the 'Application (client) ID' of an Azure App Registration.
+* `tenantId` is the 'Directory (tenant) ID' of an Azure App Registration.
 * `environment` is an optional environment name that will be appended to all Azure resources created, which allows you to create entire dev / test environments quickly and easily. This defaults to a random GUID.
 * `location` is the Azure data center location you wish to use. There are currently over 30 different data centers worldwide. This defaults to `westeurope`; the full list can be viewed [here](https://blogs.msdn.microsoft.com/uk_faculty_connection/2016/09/19/azure-data-centers-and-regions/). The location must be supplied in lower case and without spaces.
 * `pricingTier` is the pricing tier of the app service that hosts your SAFE app. This defaults to F1 (free); the full list can be viewed [here](https://azure.microsoft.com/en-us/pricing/details/app-service/).

--- a/docs/template-azure-registration.md
+++ b/docs/template-azure-registration.md
@@ -23,9 +23,9 @@ You now need to create an "App Registration" in your Azure Active Directory. Thi
 ![](img/deploy-appservice-3.png)
 1. Enter the **Name** of your application as any name e.g **SAFE Deploy**
 1. Set the **Application type** as **Native**.
-1. Set the Redirect URI as any URI e.g `http://safe-stack.github.io/`
+1. Set the Redirect URI as any URI e.g `http://localhost`
 1. Hit Create.
-1. Make a note of the **Application ID** on the blade.
+1. Make a note of the **Application (client) ID** and the **Directory (tenant) ID** on the blade.
 ![](img/deploy-appservice-4.png)
 1. Choose **Settings** from the top menu.
 1. Choose **Required Permissions** from the Settings blade.
@@ -34,5 +34,7 @@ You now need to create an "App Registration" in your Azure Active Directory. Thi
 1. Choose **Windows Azure Service Management API** and hit **Select**.
 1. Check **Access Azure Service Management as organization users (preview)** and hit **Select**.
 1. Hit **Done** from the Add API Access blade.
+1. Go back to the app registration page and select the **Manifest** from the right hand menu.
+1. Find the **allowPublicClient** json setting, and set its value to **true**
 
 Congratulations - you're now ready to use the SAFE FAKE template to perform remote deployments.


### PR DESCRIPTION
having followed these instructions, I've made some amendments to make some things a bit clearer and include a fix to enable publishing onto Azure.

1) make it clear you have to create your solution using the correct template parameters.
2) include tenantId information required for deployment, and include instructions about how to find this information
3) update the application and tenant labelling to match how it appears on the azure portal.
4) amend redirect url, to a valid one (http urls no longer allowed)
5) most importantly...include a fix to allow the publication (without it, I consistently get
AADSTS7000218: The request body must contain the following parameter: 'client_assertion' or 'client_secret')
