### PR TITLE
Use the github repo URL for Freya

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -31,6 +31,6 @@ Please also feel free to read this [blog series](https://compositional-it.com/bl
 Yes, absolutely. The above components are what we recommended as the default SAFE stack, but you can of course replace the components with alternatives as you see fit. Here are some alternative technologies which are also recommended by the SAFE team if the basic stack does not fit your needs:
 
 * [Giraffe](https://github.com/giraffe-fsharp/Giraffe) is a programming model designed for F# that runs on ASP .NET Core. As Saturn runs on top of Giraffe, you automatically get full access to it, but nonetheless it is entirely possible to write applications solely in Giraffe.
-* [Freya](https://freya.io/) is an alternative F#-first web stack which has a pluggable runtime model which allows it to be hosted in a variety of web servers including ASP .NET Core.
+* [Freya](https://github.com/xyncro/freya) is an alternative F#-first web stack which has a pluggable runtime model which allows it to be hosted in a variety of web servers including ASP .NET Core.
 * [AWS](https://aws.amazon.com/) is Amazon's cloud compute offering, providing a large number of services available globally.
 * [WebSharper](http://websharper.com/) is a complete end-to-end programming stack, comprising both server- and client-side components. It supports both F# and C# programming models.


### PR DESCRIPTION
The domain https://freya.io/ has no content and is for sale