### PR TITLE
Update Slack link to point to F# Foundation page

### DIFF
--- a/docs/support.md
+++ b/docs/support.md
@@ -19,4 +19,4 @@ Fuzzy Cloud is a fast-growing team of highly skilled and passionate IT professio
 The SAFE stack was written largely by the community as open source projects, such as Saturn, Giraffe, Fable and Elmish (as well as the alternative elements within the stack). All those teams are always happy to contribute and help out.
 
 ## Social
-You can also reach out to the SAFE team on [@safe_stack](https://twitter.com/safe_stack) or on the regular F# channels on Slack: either the official [F# Foundation Slack](https://fsharp.slack.com/messages/C04C6V0JH/?) or on the [Functional Programming Slack](https://functionalprogramming.slack.com/messages/C045LHLTH/). We'll be expanding this over time. 
+You can also reach out to the SAFE team on [@safe_stack](https://twitter.com/safe_stack) or on the regular F# channels on Slack: either the official [F# Foundation Slack](https://fsharp.org/guides/slack/) (an F# Foundation membership is required) or on the [Functional Programming Slack](https://functionalprogramming.slack.com/messages/C045LHLTH/). We'll be expanding this over time.


### PR DESCRIPTION
F# Foundation membership is required in order to access the F# Foundation slack.

There's no indication of this if you just try to access the Slack team workspace directly.