### PR TITLE
Awesome list v2

### DIFF
--- a/docs/awesome-safe-components.md
+++ b/docs/awesome-safe-components.md
@@ -1,4 +1,4 @@
-A curated list of awesome React/JS tools the community have put together:
+A set of SAFE-ready wrappers around existing React and JS UI Components. Use [femto](https://github.com/Zaid-Ajaj/Femto) to install the packages so that the npm packages are also installed.
 
 ## React bindings
 
@@ -6,12 +6,15 @@ A curated list of awesome React/JS tools the community have put together:
 Fable bindings and helpers for React and React Native. [Get it!](https://www.nuget.org/packages/Fable.React/)
 
 ### [Feliz](https://zaid-ajaj.github.io/Feliz/)
-A fresh retake of the React API in Fable and a collection of high-quality components to build React applications in F#, optimized for happiness. [Get it!](https://www.nuget.org/packages/Feliz/))
+A fresh retake of the React API in Fable and a collection of high-quality components to build React applications in F#, optimized for happiness. [Get it!](https://www.nuget.org/packages/Feliz/)
 
 ## UI Frameworks
 
 ### [Feliz.MaterialUI](https://shmew.github.io/Feliz.MaterialUI/) 
 Feliz-style Fable bindings for [Material-UI](https://material-ui.com/). [Get it!](https://www.nuget.org/packages/Feliz.MaterialUI/)
+
+### [Feliz.Reactstrap](https://nojaf.com/fable-reactstrap/) 
+Fable binding for [reactstrap](https://reactstrap.github.io/). [Get it!](https://www.nuget.org/packages/Feliz.MaterialUI/)
 
 ### [Fable.MaterialUI](https://github.com/mvsmal/fable-material-ui)
 Fable bindings for [Material-UI](https://material-ui.com/). [Get it!]((https://www.nuget.org/packages/Fable.MaterialUI/))
@@ -29,13 +32,16 @@ Fulma provides a wrapper around [Bulma 0.9.0](https://bulma.io), an open source 
 Fable bindings for [Ant Design React components](https://ant.design/). [Get it!](https://www.nuget.org/packages/Fable.AntD/)
 
 ### [Fable.FontAwesome.Free](https://github.com/Fulma/Fulma/blob/master/src/Fable.FontAwesome/Fable.FontAwesome.fsproj)
-Bindings for the Free icons of Font Awesome, should be used with Fable.FontAwesome. [Get it!](https://www.nuget.org/packages/Fable.FontAwesome.Free/))
+Bindings for the Free icons of Font Awesome, should be used with Fable.FontAwesome. [Get it!](https://www.nuget.org/packages/Fable.FontAwesome.Free/)
 
 ### [Fable.FluentUI](https://github.com/JordanMarr/Fable.FluentUI)
 [FluentUI (React)](https://www.npmjs.com/package/@fluentui/react) to Fable bindings. [Get it!](https://www.nuget.org/packages/Fable.FluentUI/) 
 
+### [Fable.ReactGridSystem](https://github.com/Prolucid/fable-react-grid-system)
+[React Grid System](https://www.npmjs.com/package/react-grid-system) to Fable bindings. [Get it!](https://www.nuget.org/packages/Fable.ReactGridSystem/) 
 
-## Components 
+
+## UI Controls
 
 ### [Feliz.Popover](https://zaid-ajaj.github.io/Feliz/#/Components/Popover)
 Feliz-style Fable bindings for [react-popover](https://github.com/littlebits/react-popover). [Get it!](https://www.nuget.org/packages/Feliz.Popover/) 
@@ -49,6 +55,15 @@ Feliz-style Fable bindings for [react-kawaii](https://react-kawaii.vercel.app/) 
 ### [Feliz.SweetAlert](https://zaid-ajaj.github.io/Feliz/#/Misc/SweetAlert)
 Feliz-style Fable bindings for [sweetalert2 and sweetalert2-react-content](https://sweetalert2.github.io/) with Feliz style api for use within React applications. Implemented as both normal functions and Elmish commands, for maximum flexibility. [Get it!](https://www.nuget.org/packages/Feliz.SweetAlert/)
 
+### [Elmish.SweetAlert](https://zaid-ajaj.github.io/Elmish.SweetAlert/)
+[SweetAlert](https://sweetalert2.github.io/) integration for Fable, made with love to work in Elmish apps. [Get it!](https://www.nuget.org/packages/Elmish.SweetAlert/)
+
+### [Elmish.Toastr](https://zaid-ajaj.github.io/Elmish.Toastr/)
+Toastr integration with Fable, implemented as Elmish commands. [Get it!](https://www.nuget.org/packages/Elmish.Toastr/)
+
+### [Elmish.AnimatedTree](https://github.com/Zaid-Ajaj/Elmish.AnimatedTree)
+A fork and binding of [react-animated-tree](https://github.com/drcmda/react-animated-tree), adapted to properly work within Elmish applications. [Get it!](https://www.nuget.org/packages/Elmish.AnimatedTree/)
+
 ### Feliz.ReactHamburger
 Feliz-style Fable bindings for [hamburger-react](https://hamburger-react.netlify.app/). [Get it!](https://www.nuget.org/packages/Feliz.ReactHamburger/)
 
@@ -58,13 +73,13 @@ Feliz-style Fable bindings for [react-select](https://react-select.com/home). [G
 ### [Fable.React.Flatpickr](https://zaid-ajaj.github.io/Fable.React.Flatpickr/)
 Fable binding for [react-flatpickr](https://www.npmjs.com/package/react-flatpickr) that is ready to use within Elmish applications. [Get it!](https://www.nuget.org/packages/Fable.React.Flatpickr/)
 
-### [Feliz.Tippy]
+### Feliz.Tippy
 Feliz-style Fable bindings for [tippyjs-react](https://github.com/atomiks/tippyjs-react). [Get it!](https://www.nuget.org/packages/Feliz.Tippy/0.0.3-alpha)
 
-### [Feliz.ReactSpeedometer]
+### Feliz.ReactSpeedometer
 Feliz-style Fable bindings for [react-d3-speedometer](https://palerdot.in/react-d3-speedometer/). [Get it!](https://www.nuget.org/packages/Feliz.ReactSpeedometer/)
 
-### [Feliz.Draggable]
+### Feliz.Draggable
 Feliz-style Fable bindings for [react-draggable](https://www.npmjs.com/package/react-draggable). [Get it!](https://www.nuget.org/packages/Feliz.Draggable/0.0.1-alpha)
 
 ### [Fable.ReactKanban](https://github.com/uxsoft/Fable.ReactKanban)
@@ -73,12 +88,18 @@ Feliz-style Fable bindings for [react-draggable](https://www.npmjs.com/package/r
 ### [Fable.React.DrawingCanvas](https://github.com/davedawkins/Fable.React.DrawingCanvas)
 This is a Fable React wrapper for canvas that allows you to declare a drawing. [Get it!](https://www.nuget.org/packages/Fable.React.DrawingCanvas/)
 
+### [Fable.GroupingPanel](https://github.com/JordanMarr/Fable.GroupingPanel)
+An F# computation expression that groups Fable UI data into one or more collapsable panels. [Get it!](https://www.nuget.org/packages/Fable.GroupingPanel/)
+
 ## Data Visualisation
 
 ### Feliz.AgGrid
 Feliz-style Fable bindings for [ag-grid](https://www.ag-grid.com/). [Get it!](https://www.nuget.org/packages/Feliz.AgGrid/)
 
-### Feliz.Reactflow](https://tforkmann.github.io/Feliz.ReactFlow/#/exampleflow)
+### [Fable.ReactAgGrid](https://danpowergruppe.github.io/Fable.ReactAgGrid/)
+Fable bindings for [ag-grid](https://www.ag-grid.com/). [Get it!](https://www.nuget.org/packages/Fable.ReactAgGrid/)
+
+### [Feliz.Reactflow](https://tforkmann.github.io/Feliz.ReactFlow/#/exampleflow)
 Feliz-style Fable bindings for [react flow](https://reactflow.dev/). [Get it!](https://www.nuget.org/packages/Feliz.Markdown/)
 
 ## Maps 

--- a/docs/awesome-safe-components.md
+++ b/docs/awesome-safe-components.md
@@ -25,9 +25,6 @@ Fable bindings for [Material-UI](https://material-ui.com/). [Get it!]((https://w
 ### [Fulma](https://fulma.github.io/Fulma/)
 Fulma provides a wrapper around [Bulma 0.9.0](https://bulma.io), an open source CSS framework, for fable-react. [Get it!](https://www.nuget.org/packages/Fulma/)
 
-### [Feliz.AntDesign](https://zaid-ajaj.github.io/Feliz.AntDesign/)
-[AntDesign](https://ant.design/) bindings using Feliz syntax for a clean, discoverable and type-safe React components. [Get it!](https://www.nuget.org/packages/Feliz.AntDesign/)
-
 ### [Fable.AntD](https://github.com/uxsoft/Fable.AntD)
 Fable bindings for [Ant Design React components](https://ant.design/). [Get it!](https://www.nuget.org/packages/Fable.AntD/)
 

--- a/docs/awesome-safe-components.md
+++ b/docs/awesome-safe-components.md
@@ -1,4 +1,16 @@
-A set of SAFE-ready wrappers around existing React and JS UI Components. Use [femto](https://github.com/Zaid-Ajaj/Femto) to install the packages so that the npm packages are also installed.
+A set of SAFE-ready wrappers around existing React and JS UI Components. 
+
+## How can I contribute my library to this list?
+
+### Required
+
+- Adding a README with installation instructions
+- Adding [femto](https://github.com/Zaid-Ajaj/Femto) metadata to the projects
+
+### Nice to have
+
+- Adding documentation with sample code on the various use cases 
+- Adding live documentation website with sample code
 
 ## React bindings
 

--- a/docs/awesome-safe-components.md
+++ b/docs/awesome-safe-components.md
@@ -2,125 +2,125 @@ A curated list of awesome React/JS tools the community have put together:
 
 ## React bindings
 
-### [Fable.React](https://www.nuget.org/packages/Fable.React/) - [Docs](https://github.com/fable-compiler/fable-react) 
-Fable bindings and helpers for React and React Native
+### [Fable.React](https://github.com/fable-compiler/fable-react) 
+Fable bindings and helpers for React and React Native. [Get it!](https://www.nuget.org/packages/Fable.React/)
 
-### [Feliz](https://www.nuget.org/packages/Feliz/) - [Docs](https://zaid-ajaj.github.io/Feliz/)
-A fresh retake of the React API in Fable and a collection of high-quality components to build React applications in F#, optimized for happiness
+### [Feliz](https://zaid-ajaj.github.io/Feliz/)
+A fresh retake of the React API in Fable and a collection of high-quality components to build React applications in F#, optimized for happiness. [Get it!](https://www.nuget.org/packages/Feliz/))
 
 ## UI Frameworks
 
-### [Feliz.MaterialUI](https://www.nuget.org/packages/Feliz.MaterialUI/) - [Docs](https://shmew.github.io/Feliz.MaterialUI/) 
-Feliz-style Fable bindings for [Material-UI](https://material-ui.com/)
+### [Feliz.MaterialUI](https://shmew.github.io/Feliz.MaterialUI/) 
+Feliz-style Fable bindings for [Material-UI](https://material-ui.com/). [Get it!](https://www.nuget.org/packages/Feliz.MaterialUI/)
 
-### [Fable.MaterialUI](https://www.nuget.org/packages/Fable.MaterialUI/)
-Fable bindings for [Material-UI](https://material-ui.com/)
+### [Fable.MaterialUI](https://github.com/mvsmal/fable-material-ui)
+Fable bindings for [Material-UI](https://material-ui.com/). [Get it!]((https://www.nuget.org/packages/Fable.MaterialUI/))
 
-### [Feliz.Bulma](https://www.nuget.org/packages/Feliz.Bulma/) - [Docs](https://www.nuget.org/packages/Feliz.Bulma/)
-[Bulma UI](https://bulma.io) wrapper for amazing Feliz DSL
+### [Feliz.Bulma](https://www.nuget.org/packages/Feliz.Bulma/)
+[Bulma UI](https://bulma.io) wrapper for amazing Feliz DSL. [Get it!](https://www.nuget.org/packages/Feliz.Bulma/)
 
-### [Fulma](https://www.nuget.org/packages/Fulma/) - [Docs](https://fulma.github.io/Fulma/)
-Fulma provides a wrapper around [Bulma 0.9.0](https://bulma.io), an open source CSS framework, for fable-react
+### [Fulma](https://fulma.github.io/Fulma/)
+Fulma provides a wrapper around [Bulma 0.9.0](https://bulma.io), an open source CSS framework, for fable-react. [Get it!](https://www.nuget.org/packages/Fulma/)
 
-### [Feliz.AntDesign](https://www.nuget.org/packages/Feliz.AntDesign/) - [Docs](https://zaid-ajaj.github.io/Feliz.AntDesign/)
-[AntDesign](https://ant.design/) bindings using Feliz syntax for a clean, discoverable and type-safe React components.
+### [Feliz.AntDesign](https://zaid-ajaj.github.io/Feliz.AntDesign/)
+[AntDesign](https://ant.design/) bindings using Feliz syntax for a clean, discoverable and type-safe React components. [Get it!](https://www.nuget.org/packages/Feliz.AntDesign/)
 
-### [Fable.AntD](https://www.nuget.org/packages/Fable.AntD/)
-Fable bindings for [Ant Design React components]((https://ant.design/))
+### [Fable.AntD](https://github.com/uxsoft/Fable.AntD)
+Fable bindings for [Ant Design React components](https://ant.design/). [Get it!](https://www.nuget.org/packages/Fable.AntD/)
 
-### [Fable.FontAwesome.Free](https://www.nuget.org/packages/Fable.FontAwesome.Free/)
-Bindings for the Free icons of Font Awesome, should be used with Fable.FontAwesome
+### [Fable.FontAwesome.Free](https://github.com/Fulma/Fulma/blob/master/src/Fable.FontAwesome/Fable.FontAwesome.fsproj)
+Bindings for the Free icons of Font Awesome, should be used with Fable.FontAwesome. [Get it!](https://www.nuget.org/packages/Fable.FontAwesome.Free/))
 
-### [Fable.FluentUI](https://www.nuget.org/packages/Fable.FluentUI/) - [Docs](https://github.com/JordanMarr/Fable.FluentUI)
-[FluentUI (React)](https://www.npmjs.com/package/@fluentui/react) to Fable bindings
+### [Fable.FluentUI](https://github.com/JordanMarr/Fable.FluentUI)
+[FluentUI (React)](https://www.npmjs.com/package/@fluentui/react) to Fable bindings. [Get it!](https://www.nuget.org/packages/Fable.FluentUI/) 
 
 
 ## Components 
 
-### [Feliz.Popover](https://www.nuget.org/packages/Feliz.Popover/) - [Docs](https://www.nuget.org/packages/Feliz.Popover/) 
-Feliz-style Fable bindings for [react-popover](https://github.com/littlebits/react-popover)
+### [Feliz.Popover](https://zaid-ajaj.github.io/Feliz/#/Components/Popover)
+Feliz-style Fable bindings for [react-popover](https://github.com/littlebits/react-popover). [Get it!](https://www.nuget.org/packages/Feliz.Popover/) 
 
-### [Feliz.SelectSearch](https://www.nuget.org/packages/Feliz.SelectSearch/) - [Docs](https://www.nuget.org/packages/Feliz.SelectSearch/)
-A binding for [react-select-search](https://react-select-search.com/) that implements a searchable and customizable dropdown for Feliz applications
+### [Feliz.SelectSearch](https://zaid-ajaj.github.io/Feliz/#/Components/SelectSearch)
+A binding for [react-select-search](https://react-select-search.com/) that implements a searchable and customizable dropdown for Feliz applications. [Get it!](https://www.nuget.org/packages/Feliz.SelectSearch/)
 
-### [Feliz.Kawaii](https://www.nuget.org/packages/Feliz.Kawaii/) - [Docs](https://www.nuget.org/packages/Feliz.Kawaii/)
-Feliz-style Fable bindings for [react-kawaii](https://react-kawaii.vercel.app/) which contains lovely SVG components
+### [Feliz.Kawaii](https://zaid-ajaj.github.io/Feliz/#/Components/Kawaii) 
+Feliz-style Fable bindings for [react-kawaii](https://react-kawaii.vercel.app/) which contains lovely SVG components. [Get it!](https://www.nuget.org/packages/Feliz.Kawaii/)
 
-### [Feliz.SweetAlert](https://www.nuget.org/packages/Feliz.SweetAlert/) - [Docs](https://www.nuget.org/packages/Feliz.SweetAlert/)
-Feliz-style Fable bindings for [sweetalert2 and sweetalert2-react-content](https://sweetalert2.github.io/) with Feliz style api for use within React applications. Implemented as both normal functions and Elmish commands, for maximum flexibility.
+### [Feliz.SweetAlert](https://zaid-ajaj.github.io/Feliz/#/Misc/SweetAlert)
+Feliz-style Fable bindings for [sweetalert2 and sweetalert2-react-content](https://sweetalert2.github.io/) with Feliz style api for use within React applications. Implemented as both normal functions and Elmish commands, for maximum flexibility. [Get it!](https://www.nuget.org/packages/Feliz.SweetAlert/)
 
-### [Feliz.ReactHamburger](https://www.nuget.org/packages/Feliz.ReactHamburger/)
-Feliz-style Fable bindings for [hamburger-react](https://hamburger-react.netlify.app/)
+### Feliz.ReactHamburger
+Feliz-style Fable bindings for [hamburger-react](https://hamburger-react.netlify.app/). [Get it!](https://www.nuget.org/packages/Feliz.ReactHamburger/)
 
-### [Feliz.ReactSelect](https://www.nuget.org/packages/Feliz.ReactSelect/0.0.1-alpha)
-Feliz-style Fable bindings for [react-select](https://react-select.com/home)
+### Feliz.ReactSelect
+Feliz-style Fable bindings for [react-select](https://react-select.com/home). [Get it!](https://www.nuget.org/packages/Feliz.ReactSelect/0.0.1-alpha)
 
-### [Fable.React.Flatpickr](https://www.nuget.org/packages/Fable.React.Flatpickr/) - [Docs](https://zaid-ajaj.github.io/Fable.React.Flatpickr/)
-Fable binding for [react-flatpickr](https://www.npmjs.com/package/react-flatpickr) that is ready to use within Elmish applications
+### [Fable.React.Flatpickr](https://zaid-ajaj.github.io/Fable.React.Flatpickr/)
+Fable binding for [react-flatpickr](https://www.npmjs.com/package/react-flatpickr) that is ready to use within Elmish applications. [Get it!](https://www.nuget.org/packages/Fable.React.Flatpickr/)
 
-### [Feliz.Tippy](https://www.nuget.org/packages/Feliz.Tippy/0.0.3-alpha)
-Feliz-style Fable bindings for [tippyjs-react](https://github.com/atomiks/tippyjs-react)
+### [Feliz.Tippy]
+Feliz-style Fable bindings for [tippyjs-react](https://github.com/atomiks/tippyjs-react). [Get it!](https://www.nuget.org/packages/Feliz.Tippy/0.0.3-alpha)
 
-### [Feliz.ReactSpeedometer](https://www.nuget.org/packages/Feliz.ReactSpeedometer/)
-Feliz-style Fable bindings for [react-d3-speedometer](https://palerdot.in/react-d3-speedometer/)
+### [Feliz.ReactSpeedometer]
+Feliz-style Fable bindings for [react-d3-speedometer](https://palerdot.in/react-d3-speedometer/). [Get it!](https://www.nuget.org/packages/Feliz.ReactSpeedometer/)
 
-### [Feliz.Draggable](https://www.nuget.org/packages/Feliz.Draggable/0.0.1-alpha)
-Feliz-style Fable bindings for [react-draggable](https://www.npmjs.com/package/react-draggable)
+### [Feliz.Draggable]
+Feliz-style Fable bindings for [react-draggable](https://www.npmjs.com/package/react-draggable). [Get it!](https://www.nuget.org/packages/Feliz.Draggable/0.0.1-alpha)
 
-### [Fable.ReactKanban](https://www.nuget.org/packages/Fable.ReactKanban/) - [Docs](https://github.com/uxsoft/Fable.ReactKanban)
-[React Kanban](https://github.com/lourenci/react-kanban) bindings for Fable React
+### [Fable.ReactKanban](https://github.com/uxsoft/Fable.ReactKanban)
+[React Kanban](https://github.com/lourenci/react-kanban) bindings for Fable React. [Get it!](https://www.nuget.org/packages/Fable.ReactKanban/)
 
-### [Fable.React.DrawingCanvas](https://www.nuget.org/packages/Fable.React.DrawingCanvas/) - [Docs](https://github.com/davedawkins/Fable.React.DrawingCanvas)
-This is a Fable React wrapper for canvas that allows you to declare a drawing
+### [Fable.React.DrawingCanvas](https://github.com/davedawkins/Fable.React.DrawingCanvas)
+This is a Fable React wrapper for canvas that allows you to declare a drawing. [Get it!](https://www.nuget.org/packages/Fable.React.DrawingCanvas/)
 
 ## Data Visualisation
 
-### [Feliz.AgGrid](https://www.nuget.org/packages/Feliz.AgGrid/)
-Feliz-style Fable bindings for [ag-grid](https://www.ag-grid.com/)
+### Feliz.AgGrid
+Feliz-style Fable bindings for [ag-grid](https://www.ag-grid.com/). [Get it!](https://www.nuget.org/packages/Feliz.AgGrid/)
 
-### [Feliz.Reactflow](https://www.nuget.org/packages/Feliz.Markdown/)
-Feliz-style Fable bindings for [react flow](https://reactflow.dev/)
+### Feliz.Reactflow](https://tforkmann.github.io/Feliz.ReactFlow/#/exampleflow)
+Feliz-style Fable bindings for [react flow](https://reactflow.dev/). [Get it!](https://www.nuget.org/packages/Feliz.Markdown/)
 
 ## Maps 
 
-### [Fable.ReactGoogleMaps](https://www.nuget.org/packages/Fable.ReactGoogleMaps/)
-Feliz-style Fable bindings for [react-google-maps](https://www.npmjs.com/package/react-google-maps)
+### [Fable.ReactGoogleMaps](https://github.com/fable-compiler/Fable.ReactGoogleMaps)
+Feliz-style Fable bindings for [react-google-maps](https://www.npmjs.com/package/react-google-maps). [Get it!](https://www.nuget.org/packages/Fable.ReactGoogleMaps/)
 
-### [Feliz.PigeonMaps](https://www.nuget.org/packages/Feliz.PigeonMaps/) - [Docs](https://zaid-ajaj.github.io/Feliz/#/Visualizations/PigeonMaps) 
-Feliz-style bindings for [pigeon-maps](https://github.com/mariusandra/pigeon-maps), React maps without external dependencies. This binding includes it's own custom PigeonMaps.marker component to build map markers manually
+### [Feliz.PigeonMaps](https://zaid-ajaj.github.io/Feliz/#/Visualizations/PigeonMaps) 
+Feliz-style bindings for [pigeon-maps](https://github.com/mariusandra/pigeon-maps), React maps without external dependencies. This binding includes it's own custom PigeonMaps.marker component to build map markers manually. [Get it!](https://www.nuget.org/packages/Feliz.PigeonMaps/) 
 
 ## Charting 
 
-### [Feliz.AgChart](https://www.nuget.org/packages/Feliz.AgChart/)
-Feliz-style bindings for [ag-charts](https://www.ag-grid.com/react-charts/overview/)
+### Feliz.AgChart
+Feliz-style bindings for [ag-charts](https://www.ag-grid.com/react-charts/overview/). [Get it!](https://www.nuget.org/packages/Feliz.AgChart/)
 
-### [Feliz.Plotly](https://www.nuget.org/packages/Feliz.Plotly/) - [Docs](https://shmew.github.io/Feliz.Plotly/)
-Fable bindings for plotly.js and react-plotly.js with Feliz style api for use within React applications. Lets you build visualizations in an easy, discoverable, and safe fashion.
+### [Feliz.Plotly](https://shmew.github.io/Feliz.Plotly/)
+Fable bindings for plotly.js and react-plotly.js with Feliz style api for use within React applications. Lets you build visualizations in an easy, discoverable, and safe fashion. [Get it!](https://www.nuget.org/packages/Feliz.Plotly/)
 
-### [Feliz.Recharts](https://www.nuget.org/packages/Feliz.Recharts/) - [Docs](https://zaid-ajaj.github.io/Feliz/#/Visualizations/Recharts)
-Feliz-style bindings for [recharts](https://recharts.org/en-US/), a composable charting library built on React components. The binding translates the original API of recharts in a one-to-one fashion but makes it type-safe and easily discoverable.
+### [Feliz.Recharts](https://zaid-ajaj.github.io/Feliz/#/Visualizations/Recharts)
+Feliz-style bindings for [recharts](https://recharts.org/en-US/), a composable charting library built on React components. The binding translates the original API of recharts in a one-to-one fashion but makes it type-safe and easily discoverable. [Get it!](https://www.nuget.org/packages/Feliz.Recharts/) 
 
-### [Feliz.RoughViz](https://www.nuget.org/packages/Feliz.RoughViz/) - [Docs](https://zaid-ajaj.github.io/Feliz/#/Visualizations/RoughViz)
-Feliz-style Fable bindings for [roughViz visualisation library](https://github.com/jwilber/roughViz). It is a fun project when your data visualisations don't need to be formal. This binding is actually made to work with original rough-viz library than renderst to the DOM rather than an existing third-party React library which makes it a nice example to learn from.
+### [Feliz.RoughViz](https://zaid-ajaj.github.io/Feliz/#/Visualizations/RoughViz)
+Feliz-style Fable bindings for [roughViz visualisation library](https://github.com/jwilber/roughViz). It is a fun project when your data visualisations don't need to be formal. This binding is actually made to work with original rough-viz library than renders to the DOM rather than an existing third-party React library which makes it a nice example to learn from. [Get it!](https://www.nuget.org/packages/Feliz.RoughViz/) 
 
 ## State management 
 
-### [Feliz.Recoil](https://www.nuget.org/packages/Feliz.Recoil/)- [Docs](https://zaid-ajaj.github.io/Feliz/#/Misc/Recoil)
-Fable bindings in Feliz style for Facebook's experimental state management library [recoil](https://github.com/facebookexperimental/Recoil).
+### [Feliz.Recoil](https://zaid-ajaj.github.io/Feliz/#/Misc/Recoil)
+Fable bindings in Feliz style for Facebook's experimental state management library [recoil](https://github.com/facebookexperimental/Recoil). [Get it!](https://www.nuget.org/packages/Feliz.Recoil/)
 
 ## Testing 
 
-### [Fable.Jester](https://zaid-ajaj.github.io/Feliz/#/Testing/Frameworks/Jest) - [Docs](https://shmew.github.io/Fable.Jester/#/)
-Fable bindings for [jest](https://jestjs.io/) and friends for delightful Fable testing
+### [Fable.Jester](https://zaid-ajaj.github.io/Feliz/#/Testing/Frameworks/Jest)
+Fable bindings for [jest](https://jestjs.io/) and friends for delightful Fable testing. [Get it!](https://www.nuget.org/packages/Fable.Jester/)
 
-### [Fable.Mocha](https://zaid-ajaj.github.io/Feliz/#/Testing/Frameworks/Mocha) - [Docs](https://zaid-ajaj.github.io/Feliz/#/Testing/Frameworks/Mocha)
-Fable library for testing. Inspired by the popular Expecto library for F# and adopts the testList, testCase and testCaseAsync primitives for defining tests.
+### [Fable.Mocha](https://zaid-ajaj.github.io/Feliz/#/Testing/Frameworks/Mocha)
+Fable library for testing. Inspired by the popular Expecto library for F# and adopts the testList, testCase and testCaseAsync primitives for defining tests. [Get it!](https://www.nuget.org/packages/Fable.Mocha/)
 
-### [Fable.ReactTestingLibrary](https://zaid-ajaj.github.io/Feliz/#/Testing/Utilities/RTL) - [Docs](https://zaid-ajaj.github.io/Feliz/#/Testing/Utilities/RTL)
-Fable bindings for [react-testing-library](https://testing-library.com/docs/react-testing-library/intro/) and user-event.
+### [Fable.ReactTestingLibrary](https://zaid-ajaj.github.io/Feliz/#/Testing/Utilities/RTL)
+Fable bindings for [react-testing-library](https://testing-library.com/docs/react-testing-library/intro/) and user-event. [Get it!](https://www.nuget.org/packages/Fable.ReactTestingLibrary/)
 
 ## Animation 
 
-### [Fun.ReactSpring](https://www.nuget.org/packages/Fun.ReactSpring/1.0.0-beta8)
-Fable bindings for [react spring](https://react-spring.io/)
+### [Fun.ReactSpring](https://github.com/albertwoo/Fun.Animation)
+Fable bindings for [react spring](https://react-spring.io/). [Get it!](https://www.nuget.org/packages/Fun.ReactSpring/1.0.0-beta8)
 

--- a/docs/recipes/package-management/add-nuget-package-to-client.md
+++ b/docs/recipes/package-management/add-nuget-package-to-client.md
@@ -1,4 +1,4 @@
 # How do I add a Nuget package to the Client?
 Adding packages to the Client project is a very [similar process to the Server](../add-nuget-package-to-server), with one important difference: Although the Client code is written in F#, at runtime it is converted into Javascript using [Fable](https://fable.io/docs/index.html). Because of this, we must be careful to only reference libraries which are [Fable compatible](https://fable.io/docs/your-fable-project/use-a-fable-library.html).
 
-There are [lots of great libraries](https://www.nuget.org/packages?q=Tags%3A%22fable%22) available to choose from.
+There are [lots of great libraries](../../awesome-safe-components.md) available to choose from.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -110,7 +110,7 @@ nav:
   - Moving from dev to prod : 'faq-build.md'
   - Troubleshooting : 'faq-troubleshooting.md'
 - Learning Resources:
-    - SAFE Components: 'awesome-safe-components.md'
+    - SAFE-Compatible UI Components: 'awesome-safe-components.md'
     - Learning: 'learning.md'
 - News: 'news.md'
 - Events: 'events.md'


### PR DESCRIPTION
- [x] Keep the title of each component as just the title. This keeps the TOC clean, too. 
- [x] I suspect most people would want to go to the website to read about the package rather than the NuGet page.
- [x] Consider putting a short section at the top which links to the section on Femto or adding client packages.
- [x] Update this page to link here, rather than the Nuget search.
- [x] I would split up the Components section, or at the very least rename to "UI Controls" or similar.
- [x] Consider renaming the page to "SAFE-Compatible UI Components" or similar - SAFE Components on its own is too generic. 
- [x] Consider changing the opening text to something like "A set of SAFE-ready wrappers around existing React and JS UI Components" or similar.