### PR TITLE
Fable 3 is no longer powered by Babel

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -26,7 +26,7 @@ Saturn can host RESTful API endpoints, drive static websites or server-generated
 Azure is a comprehensive set of cloud services that developers and IT professionals use to build, deploy and manage applications through a global network of data centres. Integrated tools, DevOps and a marketplace support you in efficiently building anything from simple mobile apps to Internet-scale solutions.
 
 ### [Fable](component-fable.md)
-Fable is an F# to JavaScript compiler powered by Babel, designed to produce readable and standard code. Fable allows you to create applications for the browser written entirely in F#, whilst also allowing you to interact with native Javascript as needed.
+Fable is an F# to JavaScript compiler, designed to produce readable and standard code. Fable allows you to create applications for the browser written entirely in F#, whilst also allowing you to interact with native Javascript as needed.
 
 ### [Elmish](component-elmish.md)
 The Elmish model allows you to construct user interfaces running in the browser using a functional programming model. Modelled on the Elm application model, Elmish uses the Model-View-Update paradigm to allow you to write applications that are simple to reason about. Elmish sits on top of the [React](https://reactjs.org/) framework.


### PR DESCRIPTION
small wording change - removed mention of Babel powering Fable