### PR TITLE
Change recipes to place tests in the tests folder

### DIFF
--- a/docs/recipes/build/docker-image.md
+++ b/docs/recipes/build/docker-image.md
@@ -86,11 +86,11 @@ services:
 ```
 To run the tests execute the command `docker-compose -f docker-compose.server.test.yml up --build`
 
-If you added tests to the **minimal template** according to the [testing the server](../developing-and-testing/testing-the-server.md) recipe, change the `workdir` to `/workspace/src/Server.Tests`
+You can add server tests to the **minimal template** with the [testing the server](../developing-and-testing/testing-the-server.md) recipe.
+
+> The template is not currently setup for automating the client tests in ci.
 
 > Docker Hub can also run [automated tests](https://docs.docker.com/docker-hub/builds/automated-testing/) for you.
-
-> The template is not currently setup for automating the client tests.
 
 > Follow [the instructions to enable Autotest](https://docs.docker.com/docker-hub/builds/automated-testing/#enable-automated-tests-on-a-repository) on docker hub.
 

--- a/docs/recipes/developing-and-testing/testing-the-client.md
+++ b/docs/recipes/developing-and-testing/testing-the-client.md
@@ -12,7 +12,7 @@ The SAFE template uses a library called Fable.Mocha which allows us to run the s
 ****
 If you are using the standard template then there is nothing more you need to do in order to start testing your Client.
 
-You will find a folder in the solution named **tests**. Inside this there is a project, **Client.Tests**, which contains a single script demonstrating how to use Mocha to test the TODO sample.
+In the tests/Client folder, there is a project named **Client.Tests** with a single script demonstrating how to use Mocha to test the TODO sample.
 
 >Note the compiler directive here which makes sure that the Shared tests are only included when executing in a Javascript (Fable) context. They are covered by Expecto under dotnet as you can see in **Server.Tests.fs**.
 
@@ -40,11 +40,11 @@ Once the build is complete and the website is running, navigate to `http://local
 If you are using the minimal template, you will need to first configure a test project as none are included.
 
 #### 1. Add a test project
-In the `src` folder, create a create a **.Net** library called **Client.Tests**.
+In the tests/Client folder, create a create a **.Net** library called **Client.Tests**.
 
 ```powershell
-dotnet new ClassLib -lang F# -o src/Client.Tests
-dotnet sln add src/Client.Tests
+dotnet new ClassLib -lang F# -n Client.Tests -o tests/Client
+dotnet sln add tests/Client
 ```
 
 #### 2. Reference the Client project
@@ -58,19 +58,20 @@ dotnet add src/Client.Tests reference src/Client
 Run the following command:
 
 ```powershell
-dotnet add src/Client.Tests package Fable.Mocha
+dotnet add tests/Client package Fable.Mocha
 ```
 
 #### 4. Add something to test
 
-Add this function to Client/Client.fs
+Add this function to Client.fs in the Client project
 
 ```fsharp
 let sayHello name = $"Hello {name}"
 ```
 
 #### 5. Add a test
-Replace the contents of Library.fs with the following code:
+Replace the contents of `tests/Client/Library.fs` with the following code:
+
 ```fsharp
 module Tests
 
@@ -95,7 +96,7 @@ let main _ = Mocha.runTests all
 
 #### 6. Add Test web page
 
-Add a file called **index.html** to the root of the test project and add the following content to it:
+Add a file called **index.html** to the tests/Client folder with following contents:
 ```html
 <!DOCTYPE html>
 <html>
@@ -109,7 +110,7 @@ Add a file called **index.html** to the root of the test project and add the fol
 
 #### 7. Add test webpack config
 
-- Add a new file root directory called **webpack.tests.config.js** with the following content
+Add a file called **webpack.tests.config.js** to the root directory with the following contents:****
 
 ```js
 // Template for webpack.config.js in Fable projects
@@ -128,10 +129,10 @@ var CopyWebpackPlugin = require('copy-webpack-plugin');
 var CONFIG = {
     // The tags to include the generated JS and CSS will be automatically injected in the HTML template
     // See https://github.com/jantimon/html-webpack-plugin
-    indexHtmlTemplate: 'src/Client.Tests/index.html',
-    fsharpEntry: 'src/Client.Tests/Library.fs.js',
-    outputDir: 'src/Client.Tests',
-    assetsDir: 'src/Client.Tests',
+    indexHtmlTemplate: 'tests/Client/index.html',
+    fsharpEntry: 'tests/Client/Library.fs.js',
+    outputDir: 'tests/Client',
+    assetsDir: 'tests/Client',
     devServerPort: 8081,
     // When using webpack-dev-server, you may need to redirect some calls
     // to a external API server. See https://webpack.js.org/configuration/dev-server/#devserver-proxy

--- a/docs/recipes/developing-and-testing/testing-the-server.md
+++ b/docs/recipes/developing-and-testing/testing-the-server.md
@@ -10,7 +10,7 @@ In this guide we will look at using **Expecto**, as this is included with the st
 
 If you are using the standard template, then there is nothing more you need to do in order to start testing your Server code.
 
-You will find a folder in the solution named **tests**. Inside this, there is a project named **Server.Tests** that contains a single script demonstrating how to use Expecto to test the TODO sample.
+In the tests/Server folder, there is a project named **Server.Tests** with a single script demonstrating how to use Expecto to test the TODO sample.
 
 In order to run the tests, instead of starting your application using
 ```powershell
@@ -25,7 +25,7 @@ This will execute the tests and print the results into the console window.
 
 <img src="../../../img/expecto-results.png"/>
 
-> This method builds and runs the Client test project too, which can be slow. If you want to run the Server tests alone, you can simply navigate to the Server.Tests directory and run the project using `dotnet run`.
+> This method builds and runs the Client test project too, which can be slow. If you want to run the Server tests alone, you can simply navigate to the tests/Server directory and run the project using `dotnet run`.
 
 ### Using dotnet test or the Visual Studio Test runner 
 
@@ -77,7 +77,7 @@ There are now two ways to run these tests.
 
 From the command line, you can just run
 ```powershell
-dotnet test src/Server.Tests
+dotnet test tests/Server
 ```
 from the root of your solution.
 
@@ -91,11 +91,11 @@ If you are using the minimal template, you will need to first configure a test p
 
 #### 1. Add a test project
 
-Create a **.Net 5** library called **Server.Tests** in the src folder.
+Create a **.Net 5** console project called **Server.Tests** in the tests/Server folder.
 
 ```powershell
-dotnet new console -lang F# -o src/Server.Tests
-dotnet sln add src/Server.Tests
+dotnet new console -lang F# -n Server.Tests -o tests/Server
+dotnet sln add tests/Server
 ```
 
 #### 2. Reference the Server project
@@ -103,7 +103,7 @@ dotnet sln add src/Server.Tests
 Reference the Server project from the Server.Tests project:
 
 ```powershell
-dotnet add src/Server.Tests reference src/Server
+dotnet add tests/Server reference src/Server
 ```
 
 #### 3. Add Expecto to the Test project
@@ -111,7 +111,7 @@ dotnet add src/Server.Tests reference src/Server
 Run the following command:
 
 ```powershell
-dotnet add src/Server.Tests package Expecto
+dotnet add tests/Server package Expecto
 ```
 
 #### 4. Add something to test
@@ -128,7 +128,7 @@ let webApp =
 
 #### 5. Add a test
 
-Replace the contents of `Program.fs` with the following:
+Replace the contents of `tests/Server/Program.fs` with the following:
 
 ``` fsharp
 open Expecto
@@ -147,7 +147,7 @@ let main _ = runTests defaultConfig server
 #### 6. Run the test
 
 ```powershell
-dotnet run -p src/Server.Tests
+dotnet run -p tests/Server
 ```
 
 This will print out the results in the console window


### PR DESCRIPTION
As discussed in https://github.com/SAFE-Stack/docs/pull/221#discussion_r651726681, this PR moves the Client.Tests and Server.Tests projects created in the client and server test recipes to the `tests/Client` and `tests/Server` folders to be consistent with the **standard** template. It also changes some of the wording to be more consistent.