### PR TITLE
Fable.Form recipe changes as per suggestions in #276 

### DIFF
--- a/docs/recipes/client-server/fable.forms.md
+++ b/docs/recipes/client-server/fable.forms.md
@@ -2,19 +2,18 @@
 
 First off, you need to create a SAFE app, [install the relevant dependencies](https://mangelmaxime.github.io/Fable.Form/Fable.Form.Simple.Bulma/installation.html), and wire them up to be available for use in your F# Fable code.
 
-- Create a new SAFE app and restore local tools:
+1. Create a new SAFE app and restore local tools:
 ```sh
 dotnet new SAFE
 dotnet tool restore
 ```
 
-- Install Fable.Form.Simple.Bulma using Paket:
+1. Install Fable.Form.Simple.Bulma using Paket:
 ```sh
 dotnet paket add --project src/Client/ Fable.Form.Simple.Bulma --version 3.0.0
 ```
 
-- Install bulma and fable-form-simple-bulma npm packages:
-
+1. Install bulma and fable-form-simple-bulma npm packages:
 ```sh
 npm add fable-form-simple-bulma
 npm add bulma@0.9.0
@@ -22,20 +21,20 @@ npm add bulma@0.9.0
 
 ## Register styles
 
-- Create `./src/Client/style.scss` with the following contents:
+1. Create `./src/Client/style.scss` with the following contents:
 ``` { .scss title="style.scss" }
 @import "~bulma";
 @import "~fable-form-simple-bulma";
 ```
 
-- Update webpack config to include the new stylesheet:
+1. Update webpack config to include the new stylesheet:
 
-    - Add a `cssEntry` property to the `CONFIG` object:
+    a. Add a `cssEntry` property to the `CONFIG` object:
     ```{ .js title="webpack.config.js" }
     cssEntry: './src/Client/style.scss',
     ```
 
-    - Modify the `entry` property of the object returned from `module.exports` to include `cssEntry`:
+    b. Modify the `entry` property of the object returned from `module.exports` to include `cssEntry`:
     ```{ .diff title="webpack.config.js" }
     -   entry: {
     -       app: resolve(config.fsharpEntry)
@@ -49,7 +48,7 @@ npm add bulma@0.9.0
     ```
     Further details of these changes can be found in the [stylesheet recipe](/docs/recipes/ui/add-style/).
 
-- Remove the Bulma stylesheet link from `./src/Client/index.html`, as it is no longer needed:
+1. Remove the Bulma stylesheet link from `./src/Client/index.html`, as it is no longer needed:
 ``` { .diff title="index.html" }
     <link rel="icon" type="image/png" href="/favicon.png"/>
 -   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.0/css/bulma.min.css">
@@ -60,31 +59,31 @@ npm add bulma@0.9.0
 
 With the above preparation done, you can use Fable.Form.Simple.Bulma in your `./src/Client/Index.fs` file.
 
-- Open the newly added namespaces:
+1. Open the newly added namespaces:
 ``` { .fsharp title="Index.fs" }
 open Fable.Form.Simple
 open Fable.Form.Simple.Bulma
 ```
 
-- Create type `Values` to represent each input field on the form (a single textbox), and create a type `Form` which is an alias for `Form.View.Model<Values>`:
+1. Create type `Values` to represent each input field on the form (a single textbox), and create a type `Form` which is an alias for `Form.View.Model<Values>`:
 ``` { .fsharp title="Index.fs" }
 type Values = { Todo: string }
 type Form = Form.View.Model<Values>
 ```
 
-- In the `Model` type definition, replace `Input: string` with `Form: Form`  
+1. In the `Model` type definition, replace `Input: string` with `Form: Form`  
 ```  { .diff title="Index.fs" }
 -type Model = { Todos: Todo list; Input: string }
 +type Model = { Todos: Todo list; Form: Form }
 ```
 
-- Update the `init` function to reflect the change in `Model`:
+1. Update the `init` function to reflect the change in `Model`:
 ```  { .diff title="Index.fs" }
 -let model = { Todos = []; Input = "" }
 +let model = { Todos = []; Form = Form.View.idle { Todo = "" } }
 ```
 
-- Change `Msg` discriminated union - replace the `SetInput` case with `FormChanged of Form`, and add string data to the `AddTodo` case:
+1. Change `Msg` discriminated union - replace the `SetInput` case with `FormChanged of Form`, and add string data to the `AddTodo` case:
 ``` { .diff title="Index.fs" }
 type Msg =
     | GotTodos of Todo list
@@ -95,7 +94,7 @@ type Msg =
     | AddedTodo of Todo
 ```
 
-- Modify the `update` function to handle the changed `Msg` cases:
+1. Modify the `update` function to handle the changed `Msg` cases:
 ``` { .diff title="Index.fs" }
 let update (msg: Msg) (model: Model) : Model * Cmd<Msg> =
     match msg with
@@ -128,7 +127,7 @@ let update (msg: Msg) (model: Model) : Model * Cmd<Msg> =
 +       newModel, Cmd.none
 ```
 
-- Create `form`. This defines the logic of the form, and how it responds to interaction:
+1. Create `form`. This defines the logic of the form, and how it responds to interaction:
 ``` { .fsharp title="Index.fs" }
 let form : Form.Form<Values, Msg, _> =
     let todoField =
@@ -150,7 +149,7 @@ let form : Form.Form<Values, Msg, _> =
     |> Form.append todoField
 ```
 
-- In the function `containerBox`, remove the existing form view. Then replace it using `Form.View.asHtml` to render the view:
+1. In the function `containerBox`, remove the existing form view. Then replace it using `Form.View.asHtml` to render the view:
     ```  { .diff title="Index.fs" }
     let containerBox (model: Model) (dispatch: Msg -> unit) =
         Bulma.box [

--- a/docs/recipes/client-server/fable.forms.md
+++ b/docs/recipes/client-server/fable.forms.md
@@ -22,157 +22,291 @@ npm add bulma@0.9.0
 ## Register styles
 
 1. Create `./src/Client/style.scss` with the following contents:
-``` { .scss title="style.scss" }
-@import "~bulma";
-@import "~fable-form-simple-bulma";
-```
+
+    === "Code"
+        ``` { .scss title="style.scss" }
+        @import "~bulma";
+        @import "~fable-form-simple-bulma";
+        ```
+    
+    === "Diff"
+        ``` { .diff title="style.scss" }
+        +@import "~bulma";
+        +@import "~fable-form-simple-bulma";
+        ```
 
 1. Update webpack config to include the new stylesheet:
 
     a. Add a `cssEntry` property to the `CONFIG` object:
-    ```{ .js title="webpack.config.js" }
-    cssEntry: './src/Client/style.scss',
-    ```
+    
+    === "Code"    
+        ```{ .js title="webpack.config.js" }
+        cssEntry: './src/Client/style.scss',
+        ```
+    
+    === "Diff"    
+        ```{ .diff title="webpack.config.js" }
+        +cssEntry: './src/Client/style.scss',
+        ```
 
     b. Modify the `entry` property of the object returned from `module.exports` to include `cssEntry`:
-    ```{ .diff title="webpack.config.js" }
-    -   entry: {
-    -       app: resolve(config.fsharpEntry)
-    -   },
-    +   entry: isProduction ? {
-    +           app: [resolve(config.fsharpEntry), resolve(config.cssEntry)]
-    +   } : {
-    +           app: resolve(config.fsharpEntry),
-    +           style: resolve(config.cssEntry)
-    +   },
-    ```
-    Further details of these changes can be found in the [stylesheet recipe](/docs/recipes/ui/add-style/).
+
+    === "Code"
+        ```{ .js title="webpack.config.js" }
+        entry: isProduction ? {
+                app: [resolve(config.fsharpEntry), resolve(config.cssEntry)]
+        } : {
+                app: resolve(config.fsharpEntry),
+                style: resolve(config.cssEntry)
+        },
+        ```
+        
+    === "Diff"
+        ```{ .diff title="webpack.config.js" }
+        -   entry: {
+        -       app: resolve(config.fsharpEntry)
+        -   },
+        +   entry: isProduction ? {
+        +           app: [resolve(config.fsharpEntry), resolve(config.cssEntry)]
+        +   } : {
+        +           app: resolve(config.fsharpEntry),
+        +           style: resolve(config.cssEntry)
+        +   },
+        ```
 
 1. Remove the Bulma stylesheet link from `./src/Client/index.html`, as it is no longer needed:
-``` { .diff title="index.html" }
-    <link rel="icon" type="image/png" href="/favicon.png"/>
--   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.0/css/bulma.min.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.14.0/css/all.min.css">
-```
+
+    ``` { .diff title="index.html (diff)" }
+        <link rel="icon" type="image/png" href="/favicon.png"/>
+    -   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.0/css/bulma.min.css">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.14.0/css/all.min.css">
+    ```
 
 ## Replace the existing form with a Fable.Form
 
 With the above preparation done, you can use Fable.Form.Simple.Bulma in your `./src/Client/Index.fs` file.
 
 1. Open the newly added namespaces:
-``` { .fsharp title="Index.fs" }
-open Fable.Form.Simple
-open Fable.Form.Simple.Bulma
-```
+
+    === "Code"
+        ``` { .fsharp title="Index.fs" }
+        open Fable.Form.Simple
+        open Fable.Form.Simple.Bulma
+        ```
+
+    === "Diff"
+        ``` { .diff title="Index.fs" }
+        +open Fable.Form.Simple
+        +open Fable.Form.Simple.Bulma
+        ```
 
 1. Create type `Values` to represent each input field on the form (a single textbox), and create a type `Form` which is an alias for `Form.View.Model<Values>`:
-``` { .fsharp title="Index.fs" }
-type Values = { Todo: string }
-type Form = Form.View.Model<Values>
-```
+
+    === "Code"
+        ``` { .fsharp title="Index.fs" }
+        type Values = { Todo: string }
+        type Form = Form.View.Model<Values>
+        ```
+
+    === "Diff"
+        ``` { .diff title="Index.fs" }
+        +type Values = { Todo: string }
+        +type Form = Form.View.Model<Values>
+        ```
 
 1. In the `Model` type definition, replace `Input: string` with `Form: Form`  
-```  { .diff title="Index.fs" }
--type Model = { Todos: Todo list; Input: string }
-+type Model = { Todos: Todo list; Form: Form }
-```
+
+    === "Code"
+        ```  { .fsharp title="Index.fs" }
+        type Model = { Todos: Todo list; Form: Form }
+        ```
+
+    === "Diff"
+        ```  { .diff title="Index.fs" }
+        -type Model = { Todos: Todo list; Input: string }
+        +type Model = { Todos: Todo list; Form: Form }
+        ```
 
 1. Update the `init` function to reflect the change in `Model`:
-```  { .diff title="Index.fs" }
--let model = { Todos = []; Input = "" }
-+let model = { Todos = []; Form = Form.View.idle { Todo = "" } }
-```
+
+    === "Code"
+        ```  { .fsharp title="Index.fs" }
+        let model = { Todos = []; Form = Form.View.idle { Todo = "" } }
+        ```
+
+    === "Diff"
+        ```  { .diff title="Index.fs" }
+        -let model = { Todos = []; Input = "" }
+        +let model = { Todos = []; Form = Form.View.idle { Todo = "" } }
+        ```
 
 1. Change `Msg` discriminated union - replace the `SetInput` case with `FormChanged of Form`, and add string data to the `AddTodo` case:
-``` { .diff title="Index.fs" }
-type Msg =
-    | GotTodos of Todo list
--   | SetInput of string
--   | AddTodo
-+   | FormChanged of Form
-+   | AddTodo of string
-    | AddedTodo of Todo
-```
+
+    === "Code"
+        ``` { .fsharp title="Index.fs" }
+        type Msg =
+            | GotTodos of Todo list
+            | FormChanged of Form
+            | AddTodo of string
+            | AddedTodo of Todo
+        ```
+
+    === "Diff"
+        ``` { .diff title="Index.fs" }
+        type Msg =
+            | GotTodos of Todo list
+        -   | SetInput of string
+        -   | AddTodo
+        +   | FormChanged of Form
+        +   | AddTodo of string
+            | AddedTodo of Todo
+        ```
 
 1. Modify the `update` function to handle the changed `Msg` cases:
-``` { .diff title="Index.fs" }
-let update (msg: Msg) (model: Model) : Model * Cmd<Msg> =
-    match msg with
-    | GotTodos todos -> { model with Todos = todos }, Cmd.none
 
-    (* First changed case *)
--   | SetInput value -> { model with Input = value }, Cmd.none
-+   | FormChanged form -> { model with Form = form }, Cmd.none
+    === "Code"
+        ``` { .fsharp title="Index.fs" }
+        let update (msg: Msg) (model: Model) : Model * Cmd<Msg> =
+            match msg with
+            | GotTodos todos -> { model with Todos = todos }, Cmd.none
+            | FormChanged form -> { model with Form = form }, Cmd.none
+            | AddTodo todo ->
+                let todo = Todo.create todo
+                let cmd = Cmd.OfAsync.perform todosApi.addTodo todo AddedTodo
+                model, cmd
+            | AddedTodo todo ->
+                let newModel =
+                    { model with
+                        Todos = model.Todos @ [ todo ]
+                        Form =
+                            { model.Form with
+                                State = Form.View.Success "Todo added"
+                                Values = { model.Form.Values with Todo = "" } } }
+                newModel, Cmd.none
+        ```
 
-    (* Second changed case *)
--   | AddTodo ->
--       let todo = Todo.create model.Input
--       let cmd = Cmd.OfAsync.perform todosApi.addTodo todo AddedTodo
--       { model with Input = "" }, cmd
-+   | AddTodo todo ->
-+       let todo = Todo.create todo
-+       let cmd = Cmd.OfAsync.perform todosApi.addTodo todo AddedTodo
-+       model, cmd
+    === "Diff"
+        ``` { .diff title="Index.fs" }
+        let update (msg: Msg) (model: Model) : Model * Cmd<Msg> =
+            match msg with
+            | GotTodos todos -> { model with Todos = todos }, Cmd.none
+        -   | SetInput value -> { model with Input = value }, Cmd.none
+        +   | FormChanged form -> { model with Form = form }, Cmd.none
+        -   | AddTodo ->
+        -       let todo = Todo.create model.Input
+        -       let cmd = Cmd.OfAsync.perform todosApi.addTodo todo AddedTodo
+        -       { model with Input = "" }, cmd
+        +   | AddTodo todo ->
+        +       let todo = Todo.create todo
+        +       let cmd = Cmd.OfAsync.perform todosApi.addTodo todo AddedTodo
+        +       model, cmd
+        -   | AddedTodo todo -> { model with Todos = model.Todos @ [ todo ] }, Cmd.none
+        +   | AddedTodo todo ->
+        +       let newModel =
+        +           { model with
+        +               Todos = model.Todos @ [ todo ]
+        +               Form =
+        +                   { model.Form with
+        +                       State = Form.View.Success "Todo added"
+        +                       Values = { model.Form.Values with Todo = "" } } }
+        +       newModel, Cmd.none
+        ```
 
-    (* Changes here also, we will now provide a success message *)
--   | AddedTodo todo -> { model with Todos = model.Todos @ [ todo ] }, Cmd.none
-+   | AddedTodo todo ->
-+       let newModel =
-+           { model with
-+               Todos = model.Todos @ [ todo ]
-+               Form =
-+                   { model.Form with
-+                       State = Form.View.Success "Todo added"
-+                       Values = { model.Form.Values with Todo = "" } } }
-+       newModel, Cmd.none
-```
 
 1. Create `form`. This defines the logic of the form, and how it responds to interaction:
-``` { .fsharp title="Index.fs" }
-let form : Form.Form<Values, Msg, _> =
-    let todoField =
-        Form.textField
-            {
-                Parser = Ok
-                Value = fun values -> values.Todo
-                Update = fun newValue values -> { values with Todo = newValue }
-                Error = fun _ -> None
-                Attributes =
-                    {
-                        Label = "New todo"
-                        Placeholder = "What needs to be done?"
-                        HtmlAttributes = []
-                    }
-            }
 
-    Form.succeed AddTodo
-    |> Form.append todoField
-```
+    === "Code"
+        ``` { .fsharp title="Index.fs" }
+        let form : Form.Form<Values, Msg, _> =
+            let todoField =
+                Form.textField
+                    {
+                        Parser = Ok
+                        Value = fun values -> values.Todo
+                        Update = fun newValue values -> { values with Todo = newValue }
+                        Error = fun _ -> None
+                        Attributes =
+                            {
+                                Label = "New todo"
+                                Placeholder = "What needs to be done?"
+                                HtmlAttributes = []
+                            }
+                    }
+
+            Form.succeed AddTodo
+            |> Form.append todoField
+        ```
+
+    === "Diff"
+        ``` { .diff title="Index.fs" }
+        +let form : Form.Form<Values, Msg, _> =
+        +    let todoField =
+        +        Form.textField
+        +            {
+        +                Parser = Ok
+        +                Value = fun values -> values.Todo
+        +                Update = fun newValue values -> { values with Todo = newValue }
+        +                Error = fun _ -> None
+        +                Attributes =
+        +                    {
+        +                        Label = "New todo"
+        +                        Placeholder = "What needs to be done?"
+        +                        HtmlAttributes = []
+        +                    }
+        +            }
+        +
+        +    Form.succeed AddTodo
+        +    |> Form.append todoField
+        ```
 
 1. In the function `containerBox`, remove the existing form view. Then replace it using `Form.View.asHtml` to render the view:
-    ```  { .diff title="Index.fs" }
-    let containerBox (model: Model) (dispatch: Msg -> unit) =
-        Bulma.box [
-            Bulma.content [
-                Html.ol [
-                    for todo in model.Todos do
-                        Html.li [ prop.text todo.Description ]
+
+    === "Code"
+        ```  { .fsharp title="Index.fs" }
+        let containerBox (model: Model) (dispatch: Msg -> unit) =
+            Bulma.box [
+                Bulma.content [
+                    Html.ol [
+                        for todo in model.Todos do
+                            Html.li [ prop.text todo.Description ]
+                    ]
                 ]
+                Form.View.asHtml
+                    {
+                        Dispatch = dispatch
+                        OnChange = FormChanged
+                        Action = Form.View.Action.SubmitOnly "Add"
+                        Validation = Form.View.Validation.ValidateOnBlur
+                    }
+                    form
+                    model.Form
             ]
-    -       Bulma.field.div [
-    -          // ... removed for brevity ...
-    -       ]
-    +       Form.View.asHtml
-    +           {
-    +               Dispatch = dispatch
-    +               OnChange = FormChanged
-    +               Action = Form.View.Action.SubmitOnly "Add"
-    +               Validation = Form.View.Validation.ValidateOnBlur
-    +           }
-    +           form
-    +           model.Form
-        ]
-    ```
+        ```
+
+    === "Diff"
+        ```  { .diff title="Index.fs" }
+        let containerBox (model: Model) (dispatch: Msg -> unit) =
+            Bulma.box [
+                Bulma.content [
+                    Html.ol [
+                        for todo in model.Todos do
+                            Html.li [ prop.text todo.Description ]
+                    ]
+                ]
+        -       Bulma.field.div [
+        -           ... removed for brevity ...
+        -       ]
+        +       Form.View.asHtml
+        +           {
+        +               Dispatch = dispatch
+        +               OnChange = FormChanged
+        +               Action = Form.View.Action.SubmitOnly "Add"
+        +               Validation = Form.View.Validation.ValidateOnBlur
+        +           }
+        +           form
+        +           model.Form
+            ]
+        ```
 
 
 ## Adding new functionality

--- a/docs/recipes/client-server/fable.forms.md
+++ b/docs/recipes/client-server/fable.forms.md
@@ -3,14 +3,12 @@
 First off, you need to create a SAFE app, [install the relevant dependencies](https://mangelmaxime.github.io/Fable.Form/Fable.Form.Simple.Bulma/installation.html), and wire them up to be available for use in your F# Fable code.
 
 - Create a new SAFE app and restore local tools:
-
 ```sh
 dotnet new SAFE
 dotnet tool restore
 ```
 
-- Install Fable.Form.Simple.Bulma via Paket:
-
+- Install Fable.Form.Simple.Bulma using Paket:
 ```sh
 dotnet paket add --project src/Client/ Fable.Form.Simple.Bulma --version 3.0.0
 ```
@@ -22,94 +20,116 @@ npm add fable-form-simple-bulma
 npm add bulma@0.9.0
 ```
 
-- Add ./src/Client/styles.scss with the following contents:
+## Register styles
 
-```scss
+- Create `./src/Client/style.scss` with the following contents:
+``` { .scss title="style.scss" }
 @import "~bulma";
 @import "~fable-form-simple-bulma";
 ```
 
-- Update ./webpack.config.js to use the new stylesheet, per the [SAFE Stack recipe](https://safe-stack.github.io/docs/recipes/ui/add-style/). Add a `cssEntry` property to `CONFIG`:
+- Update webpack config to include the new stylesheet:
 
-```js
-cssEntry: './src/Client/style.scss',
-```
+    - Add a `cssEntry` property to the `CONFIG` object:
+    ```{ .js title="webpack.config.js" }
+    cssEntry: './src/Client/style.scss',
+    ```
 
-- Also in ./webpack.config.js, update the entry property of the object returned from `module.exports`:
+    - Modify the `entry` property of the object returned from `module.exports` to include `cssEntry`:
+    ```{ .diff title="webpack.config.js" }
+    -   entry: {
+    -       app: resolve(config.fsharpEntry)
+    -   },
+    +   entry: isProduction ? {
+    +           app: [resolve(config.fsharpEntry), resolve(config.cssEntry)]
+    +   } : {
+    +           app: resolve(config.fsharpEntry),
+    +           style: resolve(config.cssEntry)
+    +   },
+    ```
+    Further details of these changes can be found in the [stylesheet recipe](/docs/recipes/ui/add-style/).
 
-```js
-entry: isProduction ? {
-    app: [resolve(CONFIG.fsharpEntry), resolve(CONFIG.cssEntry)]
-} : {
-    app: resolve(CONFIG.fsharpEntry),
-    style: resolve(CONFIG.cssEntry)
-},
-```
-
-- Remove the Bulma stylesheet link from index.html, which is no longer needed:
-
-```html
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.0/css/bulma.min.css">
+- Remove the Bulma stylesheet link from `./src/Client/index.html`, as it is no longer needed:
+``` { .diff title="index.html" }
+    <link rel="icon" type="image/png" href="/favicon.png"/>
+-   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.0/css/bulma.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.14.0/css/all.min.css">
 ```
 
 ## Replace the existing form with a Fable.Form
 
-With the above preparation done, you can use Fable.Form.Simple.Bulma in your ./src/Client/Index.fs file. For example:
+With the above preparation done, you can use Fable.Form.Simple.Bulma in your `./src/Client/Index.fs` file.
 
-- Open the namespaces:
-
-```fsharp
+- Open the newly added namespaces:
+``` { .fsharp title="Index.fs" }
 open Fable.Form.Simple
 open Fable.Form.Simple.Bulma
 ```
 
-- Update the `Model`:
-
-```fsharp
+- Create type `Values` to represent each input field on the form (a single textbox), and create a type `Form` which is an alias for `Form.View.Model<Values>`:
+``` { .fsharp title="Index.fs" }
 type Values = { Todo: string }
 type Form = Form.View.Model<Values>
-type Model = { Todos: Todo list; Form: Form }
 ```
 
-- Update the `init` function:
-
-```fsharp
-let model = { Todos = []; Form = Form.View.idle { Todo = "" } }
+- In the `Model` type definition, replace `Input: string` with `Form: Form`  
+```  { .diff title="Index.fs" }
+-type Model = { Todos: Todo list; Input: string }
++type Model = { Todos: Todo list; Form: Form }
 ```
 
-- Replace the `SetInput` `Msg` case:
-
-```fsharp
-| FormChanged of Form
+- Update the `init` function to reflect the change in `Model`:
+```  { .diff title="Index.fs" }
+-let model = { Todos = []; Input = "" }
++let model = { Todos = []; Form = Form.View.idle { Todo = "" } }
 ```
 
-- Update the `AddTodo` `Msg` case to take `string` data:
-
-```fsharp
-| AddTodo of string
+- Change `Msg` discriminated union - replace the `SetInput` case with `FormChanged of Form`, and add string data to the `AddTodo` case:
+``` { .diff title="Index.fs" }
+type Msg =
+    | GotTodos of Todo list
+-   | SetInput of string
+-   | AddTodo
++   | FormChanged of Form
++   | AddTodo of string
+    | AddedTodo of Todo
 ```
 
-- Update the `update` function accordingly:
+- Modify the `update` function to handle the changed `Msg` cases:
+``` { .diff title="Index.fs" }
+let update (msg: Msg) (model: Model) : Model * Cmd<Msg> =
+    match msg with
+    | GotTodos todos -> { model with Todos = todos }, Cmd.none
 
-```fsharp
-| FormChanged form -> { model with Form = form }, Cmd.none
-| AddTodo todo ->
-    let todo = Todo.create todo
-    model, Cmd.OfAsync.perform todosApi.addTodo todo AddedTodo
-| AddedTodo todo ->
-    let newModel =
-        { model with
-            Todos = model.Todos @ [ todo ]
-            Form =
-                { model.Form with
-                    State = Form.View.Success "Todo added"
-                    Values = { model.Form.Values with Todo = "" } } }
-    newModel, Cmd.none
+    (* First changed case *)
+-   | SetInput value -> { model with Input = value }, Cmd.none
++   | FormChanged form -> { model with Form = form }, Cmd.none
+
+    (* Second changed case *)
+-   | AddTodo ->
+-       let todo = Todo.create model.Input
+-       let cmd = Cmd.OfAsync.perform todosApi.addTodo todo AddedTodo
+-       { model with Input = "" }, cmd
++   | AddTodo todo ->
++       let todo = Todo.create todo
++       let cmd = Cmd.OfAsync.perform todosApi.addTodo todo AddedTodo
++       model, cmd
+
+    (* Changes here also, we will now provide a success message *)
+-   | AddedTodo todo -> { model with Todos = model.Todos @ [ todo ] }, Cmd.none
++   | AddedTodo todo ->
++       let newModel =
++           { model with
++               Todos = model.Todos @ [ todo ]
++               Form =
++                   { model.Form with
++                       State = Form.View.Success "Todo added"
++                       Values = { model.Form.Values with Todo = "" } } }
++       newModel, Cmd.none
 ```
 
-- Bind a Fable.Form value to `form`:
-
-```fsharp
+- Create `form`. This defines the logic of the form, and how it responds to interaction:
+``` { .fsharp title="Index.fs" }
 let form : Form.Form<Values, Msg, _> =
     let todoField =
         Form.textField
@@ -130,19 +150,30 @@ let form : Form.Form<Values, Msg, _> =
     |> Form.append todoField
 ```
 
-- Replace the Bulma TODO field with a Fable.Form html view:
-
-```fsharp
-Form.View.asHtml
-    {
-        Dispatch = dispatch
-        OnChange = FormChanged
-        Action = Form.View.Action.SubmitOnly "Add"
-        Validation = Form.View.Validation.ValidateOnSubmit
-    }
-    form
-    model.Form
-```
+- In the function `containerBox`, remove the existing form view. Then replace it using `Form.View.asHtml` to render the view:
+    ```  { .diff title="Index.fs" }
+    let containerBox (model: Model) (dispatch: Msg -> unit) =
+        Bulma.box [
+            Bulma.content [
+                Html.ol [
+                    for todo in model.Todos do
+                        Html.li [ prop.text todo.Description ]
+                ]
+            ]
+    -       Bulma.field.div [
+    -          // ... removed for brevity ...
+    -       ]
+    +       Form.View.asHtml
+    +           {
+    +               Dispatch = dispatch
+    +               OnChange = FormChanged
+    +               Action = Form.View.Action.SubmitOnly "Add"
+    +               Validation = Form.View.Validation.ValidateOnBlur
+    +           }
+    +           form
+    +           model.Form
+        ]
+    ```
 
 
 ## Adding new functionality

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,8 @@ theme:
 
 markdown_extensions:
   - codehilite
+  - pymdownx.tabbed:
+      alternate_style: true
   - pymdownx.superfences:
       custom_fences:
         - name: mermaid


### PR DESCRIPTION
This PR addresses some of the points raised in #276.

I am happy to roll bits back or to make further changes, let me know.

**Addressed in this PR**
- Source files and assets are now quoted to show as code rather than plain text
- Added a little explanation
- Clarified `cssEntry` webpack instructions (they are taken from the other recipe)
- Reworded "Bind a Fable.Form value to form" section
- Complicated changes now formatted as diffs to make details clearer
- `ValidateOnSubmit` changed to `ValidateOnBlur`
- Stylesheet filename is now consistently `style.scss`

**Additional changes**
- Switched to numbered steps
- Added file names to make it clearer which files are being modified

**Not addressed in this PR**
- Using Femto
    - `Fable.Form.Simple.Bulma` is not Femto compatible.
    - I made a Femto compatible local version intending to create a PR but Femto has a bug ([fix PR](https://github.com/Zaid-Ajaj/Femto/pull/101)) which means it doesn't work anyway.

- Is switching to NPM package for Bulma required?
    - I plan to investigate this next time
