### PR TITLE
Fix Lambda Factory links

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -38,8 +38,8 @@
 | [SAFE Stack Workshop](https://www.meetup.com/FSharpBristol/events/252393795/) | User Group | Aug 22 2018 | Bristol, UK | [Compositional IT](https://compositional-it.com) | Free
 | [SAFE apps with F# web stack](http://devsharp.pl/) | Conference | Sep 21 2018 | Gdańsk, Poland | [Tomasz Heimowski](http://theimowski.com) | Free
 | [SAFE Stack: Functional Web Programming in .NET](https://www.dddeastanglia.com/Session/Details/2179) | Conference | Sep 22 2018 | Cambridge, UK | [Compositional IT](https://compositional-it.com) | Free
-| [F# Full Stack with SAFE](https://www.openfsharp.org/agenda/workshop/) | Training | Sep 26 2018 | San Francisco, USA | [Lambda Factory](http://lambdafactory.io/) | Paid
+| [F# Full Stack with SAFE](https://www.openfsharp.org/agenda/workshop/) | Training | Sep 26 2018 | San Francisco, USA | [Lambda Factory](http://lambdafactory.pl/) | Paid
 | [SAFE Hackday](https://www.meetup.com/altnetbrum/events/252629315/) | Training | Oct 6 2018 | Birmingham, UK | [Ian Russel](https://twitter.com/ijrussell) | Free
 | [Cloud Programming with F#](https://www.eventbrite.co.uk/e/cloud-programming-with-f-tickets-48056860363) | Training | Oct 25 2018 | Berlin, Germany | [Compositional IT](https://compositional-it.com) | Paid
 | [FableConf / RemmiDemmi](http://fable.io/fableconf/#home) | Conference | Oct 26/27 2018 | Berlin, Germany | | Paid
-| [F# development with SAFE](https://techtalk.at/trainings/fsharp-development-with-safe/) | Training | Nov 7 2018 | Vienna, Austria | [Lambda Factory](http://lambdafactory.io/) | Paid
+| [F# development with SAFE](https://techtalk.at/trainings/fsharp-development-with-safe/) | Training | Nov 7 2018 | Vienna, Austria | [Lambda Factory](http://lambdafactory.pl/) | Paid

--- a/docs/support.md
+++ b/docs/support.md
@@ -5,7 +5,7 @@ The following companies provide commercial training, support, consultancy and de
 
 Compositional IT are experts in designing functional-first, cloud-ready systems, offering consultancy and support, training and development. Run by an F# MVP and well-known member of the .NET community, they are dedicated to raising awareness of the benefits of both functional programming and harnessing the power of the cloud to deliver high-quality, low-cost solutions.
 
-## [Lambda Factory](http://lambdafactory.io/)
+## [Lambda Factory](http://lambdafactory.pl/)
 <img src="../img/lambda.png" style="height: 100px;"/>
 
 Lambda Factory is a consulting company specializing in designing and building complex systems using Functional Programming languages such as F#, Elm and Elixir. It also offers help with introducing functional programming and open source driven development to the organization, as well as trainings, workshops and mentoring. Founded by open source contributor and well-known member of F# Community, Lambda Factory has been committed to supporting F# Community and helping it grow.

--- a/theme/partials/footer.html
+++ b/theme/partials/footer.html
@@ -63,7 +63,7 @@
       <!-- Copyright and theme information -->
       <div class="md-footer-copyright">
         Supported by
-        <a href="http://lambdafactory.io">
+        <a href="http://lambdafactory.pl">
           λFactory</a>
         and
         <a href="https://compositional-it.com/">


### PR DESCRIPTION
It appears the Lambda Factory domain is being squatted and that the genuine site now resides under `.pl` instead of `.io`. This PR updates the links to reflect that change.