### PR TITLE
Add recipe to remove Bulma

### DIFF
--- a/docs/recipes/ui/remove-bulma.md
+++ b/docs/recipes/ui/remove-bulma.md
@@ -1,0 +1,28 @@
+# How do I remove Bulma from a SAFE project?
+
+1. Remove / replace all the references to Bulma in the code.
+2. Optional: If using Paket make sure Fable.Core is pinned.
+
+    Edit `paket.dependencies`, set `Fable.Core < 4` - Fable 4 is not yet supported by SAFE.
+    
+    !!! warning "Dependency changes"
+        When adding or removing dependencies, it is possible an upgraded version of an existing dependency can be incompatible and cause errors. Ensure important versions are pinned to avoid this.
+    
+    !!! info
+        To avoid pinning a version when **adding** a dependency you can use the  `--keep-major` flag to make the upgrade more conservative.
+
+3. Remove `Fulma` and `Feliz.Bulma`
+
+    - Paket:
+    ```bash
+    dotnet paket remove Fulma
+    dotnet paket remove Feliz.Bulma
+    ```
+
+    - NuGet:
+    ```bash
+    cd src/Client
+    dotnet remove package Fulma
+    dotnet remove package Feliz.Bulma
+    ```
+

--- a/docs/recipes/ui/remove-bulma.md
+++ b/docs/recipes/ui/remove-bulma.md
@@ -1,7 +1,10 @@
 # How do I remove Bulma from a SAFE project?
 
-1. Remove / replace all the references to Bulma in the code.
-2. Optional: If using Paket make sure Fable.Core is pinned.
+1. Remove / replace all the references to Bulma in fsharp code
+
+1. Remove any stylesheet links to Bulma which may exist in the `index.html` page, or in other html pages.
+
+1. Optional: If using Paket make sure Fable.Core is pinned.
 
     Edit `paket.dependencies`, set `Fable.Core < 4` - Fable 4 is not yet supported by SAFE.
     
@@ -11,7 +14,7 @@
     !!! info
         To avoid pinning a version when **adding** a dependency you can use the  `--keep-major` flag to make the upgrade more conservative.
 
-3. Remove `Fulma` and `Feliz.Bulma`
+1. Remove `Fulma` and `Feliz.Bulma`
 
     - Paket:
     ```bash
@@ -25,4 +28,3 @@
     dotnet remove package Fulma
     dotnet remove package Feliz.Bulma
     ```
-

--- a/docs/recipes/ui/remove-bulma.md
+++ b/docs/recipes/ui/remove-bulma.md
@@ -4,15 +4,16 @@
 
 1. Remove any stylesheet links to Bulma which may exist in the `index.html` page, or in other html pages.
 
-1. Optional: If using Paket make sure Fable.Core is pinned.
+1. Optional: If using Paket ensure `Fable.Core` is set to a specified version.
 
-    Edit `paket.dependencies`, set `Fable.Core < 4` - Fable 4 is not yet supported by SAFE.
+    In `paket.dependencies`, make sure there is a line like so: `Fable.Core ~> 3`
     
-    !!! warning "Dependency changes"
-        When adding or removing dependencies, it is possible an upgraded version of an existing dependency can be incompatible and cause errors. Ensure important versions are pinned to avoid this.
+    !!! warning
+        SAFE is not yet compatible with newer versions of `Fable.Core`.  
+        In the past, the version was not pinned so it was possible to accidentally upgrade to an incompatible version.
     
     !!! info
-        To avoid pinning a version when **adding** a dependency you can use the  `--keep-major` flag to make the upgrade more conservative.
+        To avoid specifying a version when **adding** a dependency - if it is not already pinned to a specific version - you can use the  `--keep-major` flag to make the upgrade more conservative.
 
 1. Remove `Fulma` and `Feliz.Bulma`
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,7 @@ theme:
   logo: img/safe_favicon.png
 
 markdown_extensions:
+  - admonition
   - codehilite
   - pymdownx.tabbed:
       alternate_style: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -97,6 +97,7 @@ nav:
     - Add Stylesheet support: 'recipes/ui/add-style.md'
     - Add Bulma support: 'recipes/ui/add-bulma.md'
     - Use different Bulma Themes: 'recipes/ui/use-different-bulma-themes.md'
+    - Remove Bulma: 'recipes/ui/remove-bulma.md'
     - Add Tailwind support: 'recipes/ui/add-tailwind.md'
     - Add Feliz support: 'recipes/ui/add-feliz.md'
     - Migrate from a CDN stylesheet to an NPM package: 'recipes/ui/cdn-to-npm.md'


### PR DESCRIPTION
This PR adds a recipe explaining how to remove Bulma.

Sometimes you might want all the convenience of the full SAFE install which uses Bulma by default, but you may want to switch UI library, in which case you would probably want to remove Bulma.

One of the reasons why I wrote this up was because I ran into an issue where removing packages was causing an incompatible upgrade to `Fable.Core`. This recipe includes a step to address that issue.

This is how the recipe renders for me:
![image](https://github.com/SAFE-Stack/docs/assets/5247865/7abaed6a-e3d0-41ee-bf50-2b2d4d215e79)

