### PR TITLE
SAFE v5 - Package management documentation changes

### DIFF
--- a/docs/component-elmish.md
+++ b/docs/component-elmish.md
@@ -14,9 +14,9 @@ stateDiagram-v2
 ```
 
 ## How does Elmish integrate with SAFE?
-Elmish is the library used to build the front-end application in SAFE and that application is compiled to Javascript by [Fable](component-fable.md) to run in the browser. The [SAFE Stack template](template-overview.md) comes pre-bundled with the [Elmish React](https://elmish.github.io/react/) module, which (as the name suggests) uses the [React](https://reactjs.org/) library to handle the heavy lifting of modifyng the DOM in an efficient way. This allow us to use the pure functional style of the MVU pattern whilst still retaining the ability to have a highly performant user interface.
+Elmish is the library used to build the front-end application in SAFE and that application is compiled to JavaScript by [Fable](component-fable.md) to run in the browser. The [SAFE Stack template](template-overview.md) comes pre-bundled with the [Elmish React](https://elmish.github.io/react/) module, which (as the name suggests) uses the [React](https://reactjs.org/) library to handle the heavy lifting of modifyng the DOM in an efficient way. This allow us to use the pure functional style of the MVU pattern whilst still retaining the ability to have a highly performant user interface.
 
-Because Elmish works alongside React, it is possible to use the vast number of available React components from the Javascript ecosystem within our Elmish applications.
+Because Elmish works alongside React, it is possible to use the vast number of available React components from the JavaScript ecosystem within our Elmish applications.
 
 This conceptual diagram illustrates how the different pieces of Elmish, React and Fable fit together to make the front-end part of your SAFE application which runs in the browser.
 

--- a/docs/component-saturn.md
+++ b/docs/component-saturn.md
@@ -28,7 +28,7 @@ flowchart TB
     saturn --- giraffe --- aspnet --- kestrel
     end
     data[(Transactional Data e.g. SQL)]
-    content>Static Content e.g. HTML, CSS, Javascript]
+    content>Static Content e.g. HTML, CSS, JavaScript]
     outputs -- serves --- host
     kestrel -- reads --- data
     kestrel -- reads --- content

--- a/docs/faq-build.md
+++ b/docs/faq-build.md
@@ -25,7 +25,7 @@ c -- /api redirect --> s
 ```
 
 # Running SAFE applications in production
-In a production environment, you won't need the Webpack Dev server. Instead, Webpack is used as a one-off compiler step to create your bundled Javascript from your Fable app (plus dependencies), and then deploy this along with your backend web server which also hosts that content directly. For example, you can use Saturn to host the static content required by the application e.g. HTML, JS and CSS files etc. as well as your backend APIs. This fits very well with standard CI / CD processes, as a build step in your Build.fs or Azure DevOps / AppVeyor / Travis step etc.
+In a production environment, you won't need the Webpack Dev server. Instead, Webpack is used as a one-off compiler step to create your bundled JavaScript from your Fable app (plus dependencies), and then deploy this along with your backend web server which also hosts that content directly. For example, you can use Saturn to host the static content required by the application e.g. HTML, JS and CSS files etc. as well as your backend APIs. This fits very well with standard CI / CD processes, as a build step in your Build.fs or Azure DevOps / AppVeyor / Travis step etc.
 
 ```mermaid
 flowchart BT

--- a/docs/feature-clientserver-basics.md
+++ b/docs/feature-clientserver-basics.md
@@ -1,5 +1,5 @@
 ## Sharing Types
-Sharing your domain types and contracts between client and server is extremely simple. Thanks to Fable's excellent F# transpilation into Javascript, you can use all standard F# language features such as Records, Tuples and Discriminated Unions without worry. To share types across both your client and server project, first create a project in your repository called e.g `Shared.fsproj`. This project will contain any assets that should be shared across the client and server e.g. types and functions.
+Sharing your domain types and contracts between client and server is extremely simple. Thanks to Fable's excellent F# transpilation into JavaScript, you can use all standard F# language features such as Records, Tuples and Discriminated Unions without worry. To share types across both your client and server project, first create a project in your repository called e.g `Shared.fsproj`. This project will contain any assets that should be shared across the client and server e.g. types and functions.
 
 Then, create files with your types in the project as needed e.g
 
@@ -19,17 +19,17 @@ Reference this project from your server project. You can now reference those typ
 </Project>
 ```
 
-Finally, reference this project in your client project (as above). You can now reference those types on the client; Fable will automatically convert your F# types into Javascript in the background.
+Finally, reference this project in your client project (as above). You can now reference those types on the client; Fable will automatically convert your F# types into JavaScript in the background.
 
 ## Sharing Behaviour
 You can also share behaviour using the same mechanism at that for sharing types. This is extremely useful for e.g shared validation or business logic that needs to occur on both client and server.
 
-Fable will translate your functions into native Javascript, and will even translate many calls to the .NET base class library into corresponding Javascript! This allows you to compile your domain model and domain logic to many many different targets including:
+Fable will translate your functions into native JavaScript, and will even translate many calls to the .NET base class library into corresponding JavaScript! This allows you to compile your domain model and domain logic to many many different targets including:
 
 * ASP.NET Core (via Saturn)
 * Azure Functions
-* Javascript that runs in the browser
-* Javascript that runs on mobile devices with [React Native](https://facebook.github.io/react-native/).
+* JavaScript that runs in the browser
+* JavaScript that runs on mobile devices with [React Native](https://facebook.github.io/react-native/).
 * Raspberry Pi (via .NET Core)
 
 You can read more about this [on the Fable website](http://fable.io/docs/compatibility.html).

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -21,9 +21,9 @@ SAFE provides developers with a simple and consistent programming model for deve
 
 * Create client / server applications entirely in F#
 * Re-use development skills on client and server
-* Rapidly create rich client-side web applications with no Javascript knowledge
+* Rapidly create rich client-side web applications with no JavaScript knowledge
 * Runs on the latest .NET (and tested daily by Microsoft)
 * Rapid development cycle with support for [hot module replacement](feature-hmr.md)
-* Interact with native Javascript libraries whenever needed
+* Interact with native JavaScript libraries whenever needed
 * Create client-side applications purely in F#, with full type checking for safety
 * Seamlessly share code between client and server

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -26,7 +26,7 @@ Saturn can host RESTful API endpoints, drive static websites or server-generated
 Azure is a comprehensive set of cloud services that developers and IT professionals use to build, deploy and manage applications through a global network of data centres. Integrated tools, DevOps and a marketplace support you in efficiently building anything from simple mobile apps to Internet-scale solutions.
 
 ### [Fable](component-fable.md)
-Fable is an F# to JavaScript compiler, designed to produce readable and standard code. Fable allows you to create applications for the browser written entirely in F#, whilst also allowing you to interact with native Javascript as needed.
+Fable is an F# to JavaScript compiler, designed to produce readable and standard code. Fable allows you to create applications for the browser written entirely in F#, whilst also allowing you to interact with native JavaScript as needed.
 
 ### [Elmish](component-elmish.md)
 The Elmish model allows you to construct user interfaces running in the browser using a functional programming approach. Based upon on the Elm application model, Elmish uses the Model-View-Update paradigm to allow you to write applications that are simple to reason about. Elmish sits on top of the [React](https://reactjs.org/) framework.

--- a/docs/recipes/developing-and-testing/debug-safe-app.md
+++ b/docs/recipes/developing-and-testing/debug-safe-app.md
@@ -50,7 +50,7 @@ Since you will be running the server directly through Visual Studio, you cannot 
 Set the server as your Startup project, either using the drop-down menu at the top of the IDE or by right clicking on the project itself and selecting **Set as Startup Project**. Select the profile that you set up earlier and wish to launch from the drop-down at the top of the IDE. Either press the Play button at the top of the IDE or hit F5 on your keyboard to start the Server debugging and launch a browser pointing at the website.
 
 ### Debugging the Client
-Although we write our client-side code using F#, it is being converted into Javascript at runtime by Fable and executed in the browser.
+Although we write our client-side code using F#, it is being converted into JavaScript at runtime by Fable and executed in the browser.
 However, we can still debug it via the magic of source mapping. If you are using Visual Studio, you cannot directly connect to the browser debugger. You can, however, debug your client F# code using the browser's development tools.
 
 #### 1. Set breakpoints in Client code

--- a/docs/recipes/developing-and-testing/testing-the-client.md
+++ b/docs/recipes/developing-and-testing/testing-the-client.md
@@ -2,9 +2,9 @@
 
 Testing on the client is a little different than on the server.
 
-This is because the code which is ultimately being executed in the browser is Javascript, translated from F# by Fable, and so it must be tested in a Javascript environment.
+This is because the code which is ultimately being executed in the browser is JavaScript, translated from F# by Fable, and so it must be tested in a JavaScript environment.
 
-Furthermore, code that is shared between the Client and Server must be tested in both a dotnet environment _and_ a Javascript environment.
+Furthermore, code that is shared between the Client and Server must be tested in both a dotnet environment _and_ a JavaScript environment.
 
 The SAFE template uses a library called Fable.Mocha which allows us to run the same tests in both environments. It mirrors the Expecto API and works in much the same way.
 
@@ -14,7 +14,7 @@ If you are using the standard template then there is nothing more you need to do
 
 In the tests/Client folder, there is a project named **Client.Tests** with a single script demonstrating how to use Mocha to test the TODO sample.
 
->Note the compiler directive here which makes sure that the Shared tests are only included when executing in a Javascript (Fable) context. They are covered by Expecto under dotnet as you can see in **Server.Tests.fs**.
+>Note the compiler directive here which makes sure that the Shared tests are only included when executing in a JavaScript (Fable) context. They are covered by Expecto under dotnet as you can see in **Server.Tests.fs**.
 
 #### 1. Launch the test server
 

--- a/docs/recipes/developing-and-testing/testing-the-server.md
+++ b/docs/recipes/developing-and-testing/testing-the-server.md
@@ -156,9 +156,9 @@ This will print out the results in the console window
 
 #### 7. Using dotnet test or the Visual Studio Test Explorer
 
-Add the libraries `Microsoft.NET.Test.Sdk` and `YoloDev.Expecto.TestSdk` to your Test project, using nuget.
+Add the libraries `Microsoft.NET.Test.Sdk` and `YoloDev.Expecto.TestSdk` to your Test project, using NuGet.
 
 
-> The way you do this will depend on whether you are using nuget directly or via Paket. See [this recipe](../package-management/add-nuget-package-to-server.md) for more details.
+> The way you do this will depend on whether you are using NuGet directly or via Paket. See [this recipe](../package-management/add-nuget-package-to-server.md) for more details.
 
 You can now add `[<Test>]` attributes to your tests so that they can be discovered, and then run them using the dotnet tooling in the same way as explained earlier for the standard template.

--- a/docs/recipes/javascript/third-party-react-package.md
+++ b/docs/recipes/javascript/third-party-react-package.md
@@ -88,7 +88,7 @@ In the console window (which can be reached by right-clicking and selecting Inse
 If nothing is being seen you may need a slightly different import statement, [please refer to this recipe](../import-js-module).
 
 - `createObj` from `Fable.Core.JsInterop` takes a sequence of `string * obj` which is a prop name and value for the component, you can find the full prop list for react-d3-speedometer [here](https://www.npmjs.com/package/react-d3-speedometer).
-- Using `==>` (short hand for `prop.custom`) to transform the sequence into a javascript object 
+- Using `==>` (short hand for `prop.custom`) to transform the sequence into a JavaScript object 
 
 ```fsharp
 createObj [

--- a/docs/recipes/package-management/add-npm-package-to-client.md
+++ b/docs/recipes/package-management/add-npm-package-to-client.md
@@ -1,6 +1,6 @@
 # How do I add an NPM package to the Client?
 
-When you want to call a Javascript library from your Client, it is easy to import and reference it using [NPM](https://docs.npmjs.com/cli/npm).
+When you want to call a JavaScript library from your Client, it is easy to import and reference it using [NPM](https://docs.npmjs.com/cli/npm).
 
 Run the following command:
 ```bash

--- a/docs/recipes/package-management/add-npm-package-to-client.md
+++ b/docs/recipes/package-management/add-npm-package-to-client.md
@@ -1,6 +1,6 @@
 # How do I add an NPM package to the Client?
 
-When you want to [call a Javascript library](https://fable.io/docs/communicate/js-from-fable.html) from your Client, it is easy to import and reference it using [NPM](https://docs.npmjs.com/cli/npm).
+When you want to call a Javascript library from your Client, it is easy to import and reference it using [NPM](https://docs.npmjs.com/cli/npm).
 
 Run the following command:
 ```bash

--- a/docs/recipes/package-management/add-nuget-package-to-client.md
+++ b/docs/recipes/package-management/add-nuget-package-to-client.md
@@ -3,7 +3,7 @@ Adding packages to the Client project is a very [similar process to the Server](
 
 - Any references to the `Server` directory should be `Client`
 
-- Client code written in F# is converted into Javascript using [Fable](https://fable.io/docs/index.html). Because of this, we must be careful to only reference libraries which are [Fable compatible](https://fable.io/docs/your-fable-project/use-a-fable-library.html).
+- Client code written in F# is converted into JavaScript using [Fable](https://fable.io/docs/index.html). Because of this, we must be careful to only reference libraries which are [Fable compatible](https://fable.io/docs/your-fable-project/use-a-fable-library.html).
 
 - If the Nuget package uses any JS libraries you must install them.  
   For simplicity, [use Femto to sync](./sync-nuget-and-npm-packages.md) - if the Nuget package is compatible - or [install via NPM](./add-npm-package-to-client.md) manually, if not.

--- a/docs/recipes/package-management/add-nuget-package-to-client.md
+++ b/docs/recipes/package-management/add-nuget-package-to-client.md
@@ -1,11 +1,11 @@
-# How do I add a Nuget package to the Client?
+# How do I add a NuGet package to the Client?
 Adding packages to the Client project is a very [similar process to the Server](../add-nuget-package-to-server), with a few key differences:
 
 - Any references to the `Server` directory should be `Client`
 
 - Client code written in F# is converted into JavaScript using [Fable](https://fable.io/docs/index.html). Because of this, we must be careful to only reference libraries which are [Fable compatible](https://fable.io/docs/your-fable-project/use-a-fable-library.html).
 
-- If the Nuget package uses any JS libraries you must install them.  
-  For simplicity, [use Femto to sync](./sync-nuget-and-npm-packages.md) - if the Nuget package is compatible - or [install via NPM](./add-npm-package-to-client.md) manually, if not.
+- If the NuGet package uses any JS libraries you must install them.  
+  For simplicity, [use Femto to sync](./sync-nuget-and-npm-packages.md) - if the NuGet package is compatible - or [install via NPM](./add-npm-package-to-client.md) manually, if not.
 
 There are [lots of great libraries](../../awesome-safe-components.md) available to choose from.

--- a/docs/recipes/package-management/add-nuget-package-to-client.md
+++ b/docs/recipes/package-management/add-nuget-package-to-client.md
@@ -1,4 +1,11 @@
 # How do I add a Nuget package to the Client?
-Adding packages to the Client project is a very [similar process to the Server](../add-nuget-package-to-server), with one important difference: Although the Client code is written in F#, at runtime it is converted into Javascript using [Fable](https://fable.io/docs/index.html). Because of this, we must be careful to only reference libraries which are [Fable compatible](https://fable.io/docs/your-fable-project/use-a-fable-library.html).
+Adding packages to the Client project is a very [similar process to the Server](../add-nuget-package-to-server), with a few key differences:
+
+- Any references to the `Server` directory should be `Client`
+
+- Client code written in F# is converted into Javascript using [Fable](https://fable.io/docs/index.html). Because of this, we must be careful to only reference libraries which are [Fable compatible](https://fable.io/docs/your-fable-project/use-a-fable-library.html).
+
+- If the Nuget package uses any JS libraries you must install them.  
+  For simplicity, [use Femto to sync](./sync-nuget-and-npm-packages.md) - if the Nuget package is compatible - or [install via NPM](./add-npm-package-to-client.md) manually, if not.
 
 There are [lots of great libraries](../../awesome-safe-components.md) available to choose from.

--- a/docs/recipes/package-management/add-nuget-package-to-server.md
+++ b/docs/recipes/package-management/add-nuget-package-to-server.md
@@ -1,5 +1,5 @@
 # How do I add a Nuget package to the Server?
-You can add nuget packages to the server to give it more capabilities. You can download a wide variety of packages from [the official NuGet site](https://nuget.org/).
+You can add NuGet packages to the server to give it more capabilities. You can download a wide variety of packages from [the official NuGet site](https://nuget.org/).
 
 In this example we will add the [FsToolkit ErrorHandling package](https://www.nuget.org/packages/FsToolkit.ErrorHandling/) package.
 
@@ -16,7 +16,7 @@ dotnet paket add FsToolkit.ErrorHandling -p Server
 
 This will add an entry to both the solution [paket.dependencies](https://fsprojects.github.io/Paket/dependencies-file.html) file and the Server project's [paket.reference](https://fsprojects.github.io/Paket/references-files.html) file, as well as update the lock file with the updated dependency graph.
 
-> Find information on how you can convert your project from nuget to Paket [here](../migrate-to-paket).
+> Find information on how you can convert your project from NuGet to Paket [here](../migrate-to-paket).
 >
 > For a detailed explanation of package management using Paket, visit the official [docs](https://fsprojects.github.io/Paket/learn-how-to-use-paket.html).
 

--- a/docs/recipes/package-management/add-nuget-package-to-server.md
+++ b/docs/recipes/package-management/add-nuget-package-to-server.md
@@ -1,4 +1,4 @@
-# How do I add a Nuget package to the Server?
+# How do I add a NuGet package to the Server?
 You can add NuGet packages to the server to give it more capabilities. You can download a wide variety of packages from [the official NuGet site](https://nuget.org/).
 
 In this example we will add the [FsToolkit ErrorHandling package](https://www.nuget.org/packages/FsToolkit.ErrorHandling/) package.
@@ -38,4 +38,4 @@ Once you have done this, you will find an element in your fsproj file which look
 
 > You can also achieve the same thing using the [Visual Studio Package Manager](https://docs.microsoft.com/en-us/nuget/quickstart/install-and-use-a-package-in-visual-studio#nuget-package-manager), the [VS Mac Package Manager](https://docs.microsoft.com/en-us/nuget/quickstart/install-and-use-a-package-in-visual-studio-mac) or the [Package Manager Console](https://docs.microsoft.com/en-us/nuget/quickstart/install-and-use-a-package-in-visual-studio#package-manager-console).
 
-> For a detailed explanation of package management using Nuget, visit the official [docs](https://docs.microsoft.com/en-us/nuget/consume-packages/overview-and-workflow).
+> For a detailed explanation of package management using NuGet, visit the official [docs](https://docs.microsoft.com/en-us/nuget/consume-packages/overview-and-workflow).

--- a/docs/recipes/package-management/migrate-to-nuget.md
+++ b/docs/recipes/package-management/migrate-to-nuget.md
@@ -1,6 +1,6 @@
 # How do I migrate to NuGet from Paket?
 
->  Note that the minimal template uses Nuget by default. **This recipe only applies to the full template**.
+>  Note that the minimal template uses NuGet by default. **This recipe only applies to the full template**.
 
 Paket is a fully featured package manager that acts as an alternative to the NuGet package manager commonly used in .NET.
 

--- a/docs/recipes/package-management/migrate-to-paket.md
+++ b/docs/recipes/package-management/migrate-to-paket.md
@@ -27,6 +27,6 @@ This will add three files to your solution, all of which should be committed to 
 
 For a more detailed explanation of this process see the official [migration guide.](https://fsprojects.github.io/Paket/convert-from-nuget-tutorial.html)
 
-> In the case where you have added a nuget project to a solution which is already using paket, run this command with the option `--force`.
+> In the case where you have added a NuGet project to a solution which is already using paket, run this command with the option `--force`.
 
 > If you are working in Visual Studio and wish to see your Paket files in the Solution Explorer, you will need to add both the paket.lock and any paket.references files created in your project directories during the last step to your solution.

--- a/docs/recipes/package-management/migrate-to-paket.md
+++ b/docs/recipes/package-management/migrate-to-paket.md
@@ -14,7 +14,7 @@ dotnet tool restore
 ```
 
 #### 2. Run the Migration
-Run this command to move existing Nuget references to Paket from your packages.config or .fsproj file:
+Run this command to move existing NuGet references to Paket from your packages.config or .fsproj file:
 ```bash
 dotnet paket convert-from-nuget
 ```

--- a/docs/recipes/package-management/sync-nuget-and-npm-packages.md
+++ b/docs/recipes/package-management/sync-nuget-and-npm-packages.md
@@ -1,4 +1,4 @@
-# How do I ensure NPM and Nuget packages stay in sync?
+# How do I ensure NPM and NuGet packages stay in sync?
 SAFE Stack uses Fable bindings, which are NuGet packages that provide idiomatic and type-safe wrappers around native JavaScript APIs. These bindings often rely on third-party JavaScript libraries distributed via the NPM registry. This leads to the problem of keeping both the NPM package in sync with its corresponding NuGet F# wrapper. [Femto](https://github.com/Zaid-Ajaj/Femto) is a dotnet CLI tool that solves this issue.
 
 > For in-depth information about Femto, see [Introducing Femto](https://fable.io/blog/2019/2019-06-29-Introducing-Femto.html).

--- a/docs/recipes/ui/add-bulma.md
+++ b/docs/recipes/ui/add-bulma.md
@@ -8,7 +8,7 @@
 By adding either of these to your SAFE project alongside the [Bulma stylesheet or the Bulma NPM package](https://bulma.io/documentation/overview/start/), you can take full advantage of Bulma.
 
 ### Using Feliz.Bulma
-1. [Add the Feliz.Bulma Nuget package to the solution](./../package-management/add-nuget-package-to-client.md).
+1. [Add the Feliz.Bulma NuGet package to the solution](./../package-management/add-nuget-package-to-client.md).
 1. Start using Feliz.Bulma components in your F# files.
 ```fsharp
 open Feliz.Bulma

--- a/docs/recipes/ui/add-fontawesome.md
+++ b/docs/recipes/ui/add-fontawesome.md
@@ -13,7 +13,7 @@ If you’re using the minimal template, there are a couple of things to do befor
 
 #### 1. The NuGet Package
 Add [Fable.FontAwesome.Free NuGet Package](https://www.nuget.org/packages/Fable.FontAwesome.Free/) to the Client project.
-> See [How do I add a Nuget package to the Client?](../package-management/add-nuget-package-to-client.md).
+> See [How do I add a NuGet package to the Client?](../package-management/add-nuget-package-to-client.md).
 
 #### 2. The CDN Link
 Open the `index.html` file and add the following line to the `head` element:

--- a/docs/recipes/upgrading/v2-to-v3.md
+++ b/docs/recipes/upgrading/v2-to-v3.md
@@ -97,7 +97,7 @@ dotnet run
 ```
 at the root of the solution to launch the app and check everything is working as expected.
 
-If you have problems loading your website, carefully check that you haven't missed out any javascript or nuget packages when overwriting the paket and package files. The console output will usually give you a good guide if this is the case.
+If you have problems loading your website, carefully check that you haven't missed out any JavaScript or NuGet packages when overwriting the paket and package files. The console output will usually give you a good guide if this is the case.
 
 
 

--- a/docs/recipes/upgrading/v3-to-v4.md
+++ b/docs/recipes/upgrading/v3-to-v4.md
@@ -99,7 +99,7 @@ dotnet run
 ```
 at the root of the solution to launch the app and check everything is working as expected.
 
-If you have problems loading your website, carefully check that you haven't missed out any javascript or nuget packages when overwriting the paket and package files. The console output will usually give you a good guide if this is the case.
+If you have problems loading your website, carefully check that you haven't missed out any JavaScript or NuGet packages when overwriting the paket and package files. The console output will usually give you a good guide if this is the case.
 
 #### Issues
 

--- a/docs/v2-recipes/developing-and-testing/debug-safe-app.md
+++ b/docs/v2-recipes/developing-and-testing/debug-safe-app.md
@@ -50,7 +50,7 @@ Since you will be running the server directly through Visual Studio, you cannot 
 Set the server as your Startup project, either using the drop-down menu at the top of the IDE or by right clicking on the project itself and selecting **Set as Startup Project**. Select the profile that you set up earlier and wish to launch from the drop-down at the top of the IDE. Either press the Play button at the top of the IDE or hit F5 on your keyboard to start the Server debugging and launch a browser pointing at the website.
 
 ### Debugging the Client
-Although we write our client-side code using F#, it is being converted into Javascript at runtime by Fable and executed in the browser.
+Although we write our client-side code using F#, it is being converted into JavaScript at runtime by Fable and executed in the browser.
 However, we can still debug it via the magic of source mapping. If you are using Visual Studio, you cannot directly connect to the browser debugger. You can, however, debug your client F# code using the browser's development tools.
 
 #### 1. Set breakpoints in Client code

--- a/docs/v2-recipes/developing-and-testing/testing-the-client.md
+++ b/docs/v2-recipes/developing-and-testing/testing-the-client.md
@@ -2,9 +2,9 @@
 
 Testing on the client is a little different than on the server.
 
-This is because the code which is ultimately being executed in the browser is Javascript, translated from F# by Fable, and so it must be tested in a Javascript environment.
+This is because the code which is ultimately being executed in the browser is JavaScript, translated from F# by Fable, and so it must be tested in a JavaScript environment.
 
-Furthermore, code that is shared between the Client and Server must be tested in both a dotnet environment _and_ a Javascript environment.
+Furthermore, code that is shared between the Client and Server must be tested in both a dotnet environment _and_ a JavaScript environment.
 
 The SAFE template uses a library called Fable.Mocha which allows us to run the same tests in both environments. It mirrors the Expecto API and works in much the same way.
 
@@ -14,7 +14,7 @@ If you are using the standard template then there is nothing more you need to do
 
 You will find a folder in the solution named **tests**. Inside this there is a project, **Client.Tests**, which contains a single script demonstrating how to use Mocha to test the TODO sample.
 
->Note the compiler directive here which makes sure that the Shared tests are only included when executing in a Javascript (Fable) context. They are covered by Expecto under dotnet as you can see in **Server.Tests.fs**.
+>Note the compiler directive here which makes sure that the Shared tests are only included when executing in a JavaScript (Fable) context. They are covered by Expecto under dotnet as you can see in **Server.Tests.fs**.
 
 #### 1. Launch the test server
 

--- a/docs/v2-recipes/package-management/migrate-to-yarn.md
+++ b/docs/v2-recipes/package-management/migrate-to-yarn.md
@@ -1,6 +1,6 @@
 #How do I migrate to Yarn from NPM?
 
-[Yarn](https://yarnpkg.com/) is an alternative Javascript package manager created by Facebook. 
+[Yarn](https://yarnpkg.com/) is an alternative JavaScript package manager created by Facebook. 
 
 When it was first released it provided several features which were absent from NPM at the time such as [offline caching](https://yarnpkg.com/features/offline-cache) and [deterministic dependency resolution](https://classic.yarnpkg.com/blog/2016/11/24/lockfiles-for-all/). 
 

--- a/docs/v2-recipes/upgrading/v1-to-v2.md
+++ b/docs/v2-recipes/upgrading/v1-to-v2.md
@@ -140,7 +140,7 @@ dotnet fake build -t run
 ```
 at the root of the solution to launch the app and check everything is working as expected.
 
-If you have problems loading your website, carefully check that you haven't missed out any javascript or nuget packages when overwriting the paket and package files. The console output will usually give you a good guide if this is the case.
+If you have problems loading your website, carefully check that you haven't missed out any JavaScript or NuGet packages when overwriting the paket and package files. The console output will usually give you a good guide if this is the case.
 
 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,7 +105,7 @@ nav:
     - Add routing with state shared between pages: 'recipes/ui/add-routing.md'
     - Add routing with separate models per page: 'recipes/ui/add-routing-with-separate-models.md'
     - Add Routing with UseElmish: 'recipes/ui/routing-with-elmish.md'
-  - Javascript:
+  - JavaScript:
     - Import a JavaScript module: 'recipes/javascript/import-js-module.md'
     - Add Support for a Third Party React Library: 'recipes/javascript/third-party-react-package.md'
   - Package Management:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -111,7 +111,7 @@ nav:
   - Package Management:
     - Add an NPM package to the Client: 'recipes/package-management/add-npm-package-to-client.md'
     - Add a NuGet package to the Server: 'recipes/package-management/add-nuget-package-to-server.md'
-    - Add a Nuget package to the Client: 'recipes/package-management/add-nuget-package-to-client.md'
+    - Add a NuGet package to the Client: 'recipes/package-management/add-nuget-package-to-client.md'
     - Migrate to Paket from NuGet: 'recipes/package-management/migrate-to-paket.md'
     - Migrate to NuGet from Paket: 'recipes/package-management/migrate-to-nuget.md'
     - Sync NuGet and NPM Packages: 'recipes/package-management/sync-nuget-and-npm-packages.md'


### PR DESCRIPTION
I checked all the recipes in `docs/recipes/package-management/` for anything which needs to be changed going from SAFE v4 to v5 and as far as I can tell there is nothing.

Since I was going through them anyway I made some minor tweaks which are unrelated to the upcoming release of SAFE v5.

Just in case something non-obvious had broken, I ran through most of the instructions with the new template and everything seems fine.