### PR TITLE
instructions for v5 upgrade

### DIFF
--- a/docs/recipes/upgrading/v4-to-v5.md
+++ b/docs/recipes/upgrading/v4-to-v5.md
@@ -164,22 +164,6 @@
 	}
 	```
 
-1. In order to get VSCode Tailwind intellisense, user needs to install `Tailwind CSS Intellisense`. We also create the file `.vscode/settings.json` with the following content.
-
-	*The regex here are for Feliz style DSL, if you want to support Fable.React DSL you need to adapt the regexes*
-	
-	```json
-	{
-	    "tailwindCSS.includeLanguages": {
-	        "fsharp": "html"
-	    },
-	    "tailwindCSS.experimental.classRegex": [
-	        "\\.className\\s+\"([^\"]*)\"",
-	        ["\\.className\\s+\\[([^\\]]*)\\]", "\"([^\"]*)\""]
-	    ]
-	}
-	```
-
 1. Create a file `src/Client/index.css` with the following content
 
 	```css
@@ -338,4 +322,22 @@
 	```diff
 	- "client", dotnet [ "fable"; "watch"; "-o"; "output"; "-s"; "--run"; "npm"; "run"; "test:live" ] clientTestsPath ]
 	+ "client", dotnet [ "fable"; "watch"; "-o"; "output"; "-s"; "--run"; "npx"; "vite" ] clientTestsPath ]
+	```
+
+### Additional resources
+
+In order to get VSCode Tailwind intellisense, user needs to install `Tailwind CSS Intellisense`. We also create the file `.vscode/settings.json` with the following content.
+
+	*The regex here are for Feliz style DSL, if you want to support Fable.React DSL you need to adapt the regexes*
+	
+	```json
+	{
+	    "tailwindCSS.includeLanguages": {
+	        "fsharp": "html"
+	    },
+	    "tailwindCSS.experimental.classRegex": [
+	        "\\.className\\s+\"([^\"]*)\"",
+	        ["\\.className\\s+\\[([^\\]]*)\\]", "\"([^\"]*)\""]
+	    ]
+	}
 	```

--- a/docs/recipes/upgrading/v4-to-v5.md
+++ b/docs/recipes/upgrading/v4-to-v5.md
@@ -63,8 +63,8 @@
 	```
 	
 	- Run `dotnet paket install`
-	- Remove `Fable.React` and `Feliz.Bulma` from `src/Client/paket.references` (moved here according to @Freymaurer feedback)
-    - Run `dotnet paket update Fable.Remoting.Client`, needs to be done separately because version changes is a minor one and not major so I can't force it using only the `paket.dependencies` changes
+	- Run `dotnet paket remove Fable.React -p Client`
+	- Run `dotnet paket remove Feliz.Bulma -p Client`
 
 1. Remove all the webpack related dependencies:
 

--- a/docs/recipes/upgrading/v4-to-v5.md
+++ b/docs/recipes/upgrading/v4-to-v5.md
@@ -31,39 +31,10 @@
 
 1. Upgrade .NET dependencies to latest versions:
 
-	Update your `paket.dependencies` with:
-		
-	```
-	source https://api.nuget.org/v3/index.json
-	framework: net8.0
-	storage: none
-	
-	nuget Fsharp.Core ~> 8
+	- Run `dotnet paket remove Fable.React -p Client`
+	- Run `dotnet paket remove Feliz.Bulma -p Client`
 
-    //Server
-	nuget Fable.Remoting.Giraffe ~> 5
-	nuget Saturn ~> 0
-	
-    //Client
-	nuget Fable.Core ~> 4
-	nuget Fable.Elmish ~> 4
-	nuget Fable.Elmish.React ~> 4
-	nuget Fable.Elmish.Debugger ~> 4
-	nuget Fable.Elmish.HMR ~> 7
-	nuget Fable.Remoting.Client ~> 7
-	nuget Feliz ~> 2
-	
-    //Build
-	nuget Fake.Core.Target ~> 5
-	nuget Fake.IO.FileSystem ~> 5
-	nuget Farmer ~> 1
-
-    //Testing
-	nuget Fable.Mocha ~> 2
-	nuget Expecto ~> 9
-
-	//Any other packages you already have here
-	```
+	Update your `paket.dependencies` with the current file [here](https://github.com/SAFE-Stack/SAFE-template/blob/master/Content/default/paket.dependencies)
 
 	Update your `paket.lock` with the current file [here](https://github.com/SAFE-Stack/SAFE-template/blob/master/Content/default/paket.lock)
 	
@@ -73,8 +44,6 @@
 	FSharp.Core
 	```
 
-	- Run `dotnet paket remove Fable.React -p Client`
-	- Run `dotnet paket remove Feliz.Bulma -p Client`
 	- Run `dotnet paket restore`
 
 1. Remove all the webpack related dependencies:

--- a/docs/recipes/upgrading/v4-to-v5.md
+++ b/docs/recipes/upgrading/v4-to-v5.md
@@ -61,11 +61,15 @@
     //Testing
 	nuget Fable.Mocha ~> 2
 	nuget Expecto ~> 9
+
+	//Any other packages you already have here
 	```
+
+	Update your `paket.lock` with the current file [here](https://github.com/SAFE-Stack/SAFE-template/blob/master/Content/default/paket.lock)
 	
-	- Run `dotnet paket install`
 	- Run `dotnet paket remove Fable.React -p Client`
 	- Run `dotnet paket remove Feliz.Bulma -p Client`
+	- Run `dotnet paket install`
 
 	Add a `paket.references` file to `src/Shared` with the following
 
@@ -98,7 +102,7 @@
     }
 	```
 
-	and install the relevent version of `node` and `npm`
+	and install the relevant version of `node` and `npm`
 
 	**Tip**: Node Version Manage or `nvm` can be used to install and manage node/npm versions
 
@@ -207,81 +211,7 @@
 	importSideEffects "./index.css"
 	```
 
-1. In `src/Client/Index.fs` replace all view code after the `update` function with the following 
-
-	```fsharp
-		open Feliz
-
-		let private todoAction model dispatch =
-			Html.div [
-				prop.className "flex flex-col sm:flex-row mt-4 gap-4"
-				prop.children [
-					Html.input [
-						prop.className
-							"shadow appearance-none border rounded w-full py-2 px-3 outline-none focus:ring-2 ring-teal-300 text-grey-darker"
-						prop.value model.Input
-						prop.placeholder "What needs to be done?"
-						prop.autoFocus true
-						prop.onChange (SetInput >> dispatch)
-						prop.onKeyPress (fun ev ->
-							if ev.key = "Enter" then
-								dispatch AddTodo)
-					]
-					Html.button [
-						prop.className
-							"flex-no-shrink p-2 px-12 rounded bg-teal-600 outline-none focus:ring-2 ring-teal-300 font-bold text-white hover:bg-teal disabled:opacity-30 disabled:cursor-not-allowed"
-						prop.disabled (Todo.isValid model.Input |> not)
-						prop.onClick (fun _ -> dispatch AddTodo)
-						prop.text "Add"
-					]
-				]
-			]
-
-		let private todoList model dispatch =
-			Html.div [
-				prop.className "bg-white/80 rounded-md shadow-md p-4 w-5/6 lg:w-3/4 lg:max-w-2xl"
-				prop.children [
-					Html.ol [
-						prop.className "list-decimal ml-6"
-						prop.children [
-							for todo in model.Todos do
-								Html.li [ prop.className "my-1"; prop.text todo.Description ]
-						]
-					]
-
-					todoAction model dispatch
-				]
-			]
-
-		let view model dispatch =
-			Html.section [
-				prop.className "h-screen w-screen"
-				prop.style [
-					style.backgroundSize "cover"
-					style.backgroundImageUrl "https://unsplash.it/1200/900?random"
-					style.backgroundPosition "no-repeat center center fixed"
-				]
-
-				prop.children [
-					Html.a [
-						prop.href "https://safe-stack.github.io/"
-						prop.className "absolute block ml-12 h-12 w-12 bg-teal-300 hover:cursor-pointer hover:bg-teal-400"
-						prop.children [ Html.img [ prop.src "/favicon.png"; prop.alt "Logo" ] ]
-					]
-
-					Html.div [
-						prop.className "flex flex-col items-center justify-center h-full"
-						prop.children [
-							Html.h1 [
-								prop.className "text-center text-5xl font-bold text-white mb-3 rounded-md p-4"
-								prop.text "SAFE.App"
-							]
-							todoList model dispatch
-						]
-					]
-				]
-			]
-	```
+1. In `src/Client/Index.fs` replace all view code after the `update` function with the code [here](https://github.com/SAFE-Stack/SAFE-template/blob/master/Content/default/src/Client/Index.fs)
 
 1. Create a file `tests/Client/vite.config.mts` with the following content:
 
@@ -317,7 +247,7 @@
 	src/Client/output/fable_modules/ 
 	```
 
-1. In the `build.fs` file replace the following lines:
+1. In the `Build.fs` file replace the following lines:
 
 	Line 27:
 	

--- a/docs/recipes/upgrading/v4-to-v5.md
+++ b/docs/recipes/upgrading/v4-to-v5.md
@@ -82,6 +82,27 @@
 	    webpack-cli \
 	    webpack-dev-server
 	```
+
+1. Update the `engines` in `package.json` to the following
+
+	```
+	"engines": {
+        "node": "~18 || ~20",
+        "npm": "~9 || ~10"
+    }
+	```
+
+	and install the relevent version of `node` and `npm`
+
+	**Tip**: Node Version Manage or `nvm` can be used to install and manage node/npm versions
+
+1. Remove any existing `scripts` from the `package.json` that relate to `webpack` or `webpack-dev-server`
+
+	```diff
+	- "start": "webpack-dev-server --mode development",
+	- "build": "webpack --mode production",
+	- "test:live": "webpack-dev-server --mode development --env test"
+	```
 	
 1. Update the left over NPM dependencies:
 
@@ -288,14 +309,6 @@
 	```
 	# Ignore Fable files
 	src/Client/output/fable_modules/ 
-	```
-
-1. Remove any existing `scripts` from the `package.json` that relate to `webpack` or `webpack-dev-server`
-
-	```diff
-	- "start": "webpack-dev-server --mode development",
-	- "build": "webpack --mode production",
-	- "test:live": "webpack-dev-server --mode development --env test"
 	```
 
 1. In the `build.fs` file replace the following lines:

--- a/docs/recipes/upgrading/v4-to-v5.md
+++ b/docs/recipes/upgrading/v4-to-v5.md
@@ -29,7 +29,7 @@
     </PropertyGroup>
     ```
 
-1. Upgrade .NET dependencies to latest version:
+1. Upgrade .NET dependencies to latest versions:
 
 	Update your `paket.dependencies` with:
 		
@@ -66,6 +66,12 @@
 	- Run `dotnet paket install`
 	- Run `dotnet paket remove Fable.React -p Client`
 	- Run `dotnet paket remove Feliz.Bulma -p Client`
+
+	Add a `paket.references` file to `src/Shared` with the following
+
+	```
+	FSharp.Core
+	```
 
 1. Remove all the webpack related dependencies:
 

--- a/docs/recipes/upgrading/v4-to-v5.md
+++ b/docs/recipes/upgrading/v4-to-v5.md
@@ -89,9 +89,13 @@
 	
 	If you use the second option, make sure to select `react`, `react-dom`, `sass`.
 	
+	> Note: if you have any problems with the versions of the npm packages, try installing the exact versions that are in the [SAFE Template's package.json](https://github.com/SAFE-Stack/SAFE-template/blob/master/Content/default/package.json)
+
 1. Install the new NPM dependencies
 
 	`npm install -D vite @vitejs/plugin-react tailwindcss postcss autoprefixer @types/node`
+
+	> Note: if you have any problems with the versions of the npm packages, try installing the exact versions that are in the [SAFE Template's package.json](https://github.com/SAFE-Stack/SAFE-template/blob/master/Content/default/package.json)
 	
 1. Delete `webpack.config.js`
 
@@ -172,7 +176,7 @@
 	@tailwind utilities;
 	```
 	
-1. Add the following lines at the top of `src/Client/App.fs`
+1. Add the following lines at the top of `src/Client/App.fs`, after the existing open declarations
 	
 	```fs
 	open Fable.Core.JsInterop
@@ -180,7 +184,7 @@
 	importSideEffects "./index.css"
 	```
 
-1. In `src/Client/Index.fs` replace all view code after the `update` function with the code [here](https://github.com/SAFE-Stack/SAFE-template/blob/master/Content/default/src/Client/Index.fs#L42-L112)
+1. In `src/Client/Index.fs` replace all view code after the `update` function with the code [here](https://github.com/SAFE-Stack/SAFE-template/blob/064b902c4ca8229f8f671a3fab67c2871cd772c1/Content/default/src/Client/Index.fs#L42-L112)
 
 1. Create a file `tests/Client/vite.config.mts` with the following content:
 

--- a/docs/recipes/upgrading/v4-to-v5.md
+++ b/docs/recipes/upgrading/v4-to-v5.md
@@ -6,6 +6,7 @@
     - `dotnet tool update paket`
     - `dotnet tool update fantomas`
     - `dotnet tool update femto`
+	- `dotnet tool restore`
 
 1. Remove `fantomas-tool` by running `dotnet tool uninstall fantomas-tool`
     

--- a/docs/recipes/upgrading/v4-to-v5.md
+++ b/docs/recipes/upgrading/v4-to-v5.md
@@ -330,6 +330,13 @@
 	+ "client", dotnet [ "fable"; "watch"; "-o"; "output"; "-s"; "--run"; "npx"; "vite" ] clientTestsPath ]
 	```
 
+	**Note**: If you are using a template created prior to version v4.3, you may have the following string syntax for the `dotnet` commands and therefore the change you need to make will be slightly different.
+
+	```diff
+	- "client", dotnet "fable -o output -s --run npm run build" clientPath
+	+ "client", dotnet "fable -o output -s --run npx vite build" clientPath
+	```
+
 ### Additional resources
 
 In order to get VSCode Tailwind intellisense, user needs to install `Tailwind CSS Intellisense`. We also create the file `.vscode/settings.json` with the following content.

--- a/docs/recipes/upgrading/v4-to-v5.md
+++ b/docs/recipes/upgrading/v4-to-v5.md
@@ -67,15 +67,15 @@
 
 	Update your `paket.lock` with the current file [here](https://github.com/SAFE-Stack/SAFE-template/blob/master/Content/default/paket.lock)
 	
-	- Run `dotnet paket remove Fable.React -p Client`
-	- Run `dotnet paket remove Feliz.Bulma -p Client`
-	- Run `dotnet paket install`
-
 	Add a `paket.references` file to `src/Shared` with the following
 
 	```
 	FSharp.Core
 	```
+
+	- Run `dotnet paket remove Fable.React -p Client`
+	- Run `dotnet paket remove Feliz.Bulma -p Client`
+	- Run `dotnet paket restore`
 
 1. Remove all the webpack related dependencies:
 

--- a/docs/recipes/upgrading/v4-to-v5.md
+++ b/docs/recipes/upgrading/v4-to-v5.md
@@ -196,7 +196,81 @@
 	importSideEffects "./index.css"
 	```
 
-1. Overwrite `src/Client/Index.fs` with the new version of the file (see the diff)
+1. In `src/Client/Index.fs` replace all view code after the `update` function with the following 
+
+	```fsharp
+		open Feliz
+
+		let private todoAction model dispatch =
+			Html.div [
+				prop.className "flex flex-col sm:flex-row mt-4 gap-4"
+				prop.children [
+					Html.input [
+						prop.className
+							"shadow appearance-none border rounded w-full py-2 px-3 outline-none focus:ring-2 ring-teal-300 text-grey-darker"
+						prop.value model.Input
+						prop.placeholder "What needs to be done?"
+						prop.autoFocus true
+						prop.onChange (SetInput >> dispatch)
+						prop.onKeyPress (fun ev ->
+							if ev.key = "Enter" then
+								dispatch AddTodo)
+					]
+					Html.button [
+						prop.className
+							"flex-no-shrink p-2 px-12 rounded bg-teal-600 outline-none focus:ring-2 ring-teal-300 font-bold text-white hover:bg-teal disabled:opacity-30 disabled:cursor-not-allowed"
+						prop.disabled (Todo.isValid model.Input |> not)
+						prop.onClick (fun _ -> dispatch AddTodo)
+						prop.text "Add"
+					]
+				]
+			]
+
+		let private todoList model dispatch =
+			Html.div [
+				prop.className "bg-white/80 rounded-md shadow-md p-4 w-5/6 lg:w-3/4 lg:max-w-2xl"
+				prop.children [
+					Html.ol [
+						prop.className "list-decimal ml-6"
+						prop.children [
+							for todo in model.Todos do
+								Html.li [ prop.className "my-1"; prop.text todo.Description ]
+						]
+					]
+
+					todoAction model dispatch
+				]
+			]
+
+		let view model dispatch =
+			Html.section [
+				prop.className "h-screen w-screen"
+				prop.style [
+					style.backgroundSize "cover"
+					style.backgroundImageUrl "https://unsplash.it/1200/900?random"
+					style.backgroundPosition "no-repeat center center fixed"
+				]
+
+				prop.children [
+					Html.a [
+						prop.href "https://safe-stack.github.io/"
+						prop.className "absolute block ml-12 h-12 w-12 bg-teal-300 hover:cursor-pointer hover:bg-teal-400"
+						prop.children [ Html.img [ prop.src "/favicon.png"; prop.alt "Logo" ] ]
+					]
+
+					Html.div [
+						prop.className "flex flex-col items-center justify-center h-full"
+						prop.children [
+							Html.h1 [
+								prop.className "text-center text-5xl font-bold text-white mb-3 rounded-md p-4"
+								prop.text "SAFE.App"
+							]
+							todoList model dispatch
+						]
+					]
+				]
+			]
+	```
 
 1. Create a file `tests/Client/vite.config.mts` with the following content:
 

--- a/docs/recipes/upgrading/v4-to-v5.md
+++ b/docs/recipes/upgrading/v4-to-v5.md
@@ -290,7 +290,13 @@
 	src/Client/output/fable_modules/ 
 	```
 
-1. Remove the existing `scripts` from the `package.json`, should be `"scripts": {},` now.
+1. Remove any existing `scripts` from the `package.json` that relate to `webpack` or `webpack-dev-server`
+
+	```diff
+	- "start": "webpack-dev-server --mode development",
+	- "build": "webpack --mode production",
+	- "test:live": "webpack-dev-server --mode development --env test"
+	```
 
 1. In the `build.fs` file replace the following lines:
 

--- a/docs/recipes/upgrading/v4-to-v5.md
+++ b/docs/recipes/upgrading/v4-to-v5.md
@@ -316,6 +316,15 @@
 	- "client", dotnet [ "fable"; "-o"; "output"; "-s"; "--run"; "npm"; "run"; "build" ] clientPath ]
 	+ "client", dotnet [ "fable"; "-o"; "output"; "-s"; "--run"; "npx"; "vite"; "build" ] clientPath ]
 	```
+
+	Line 35:
+
+	```diff
+	- operating_system OS.Windows
+	- runtime_stack Runtime.DotNet60
+	+ operating_system OS.Linux
+	+ runtime_stack (DotNet "8.0")
+	```
 	
 	Line 51:
 	

--- a/docs/recipes/upgrading/v4-to-v5.md
+++ b/docs/recipes/upgrading/v4-to-v5.md
@@ -65,8 +65,6 @@
 	- Run `dotnet paket install`
 	- Remove `Fable.React` and `Feliz.Bulma` from `src/Client/paket.references` (moved here according to @Freymaurer feedback)
     - Run `dotnet paket update Fable.Remoting.Client`, needs to be done separately because version changes is a minor one and not major so I can't force it using only the `paket.dependencies` changes
-    - Run `dotnet paket update Fake.Core.Target`
-    - Run `dotnet paket update Fake.IO.FileSystem`
 
 1. Remove all the webpack related dependencies:
 

--- a/docs/recipes/upgrading/v4-to-v5.md
+++ b/docs/recipes/upgrading/v4-to-v5.md
@@ -34,15 +34,15 @@
 	- Run `dotnet paket remove Fable.React -p Client`
 	- Run `dotnet paket remove Feliz.Bulma -p Client`
 
-	Update your `paket.dependencies` with the current file [here](https://github.com/SAFE-Stack/SAFE-template/blob/master/Content/default/paket.dependencies)
+	- Update your `paket.dependencies` with the current file [here](https://github.com/SAFE-Stack/SAFE-template/blob/master/Content/default/paket.dependencies)
 
-	Update your `paket.lock` with the current file [here](https://github.com/SAFE-Stack/SAFE-template/blob/master/Content/default/paket.lock)
+	- Update your `paket.lock` with the current file [here](https://github.com/SAFE-Stack/SAFE-template/blob/master/Content/default/paket.lock)
 	
-	Add a `paket.references` file to `src/Shared` with the following
+	- Add a `paket.references` file to `src/Shared` with the following
 
-	```
-	FSharp.Core
-	```
+		```
+		FSharp.Core
+		```
 
 	- Run `dotnet paket restore`
 

--- a/docs/recipes/upgrading/v4-to-v5.md
+++ b/docs/recipes/upgrading/v4-to-v5.md
@@ -37,7 +37,7 @@
 	framework: net8.0
 	storage: none
 	
-	nuget Fsharp.Core
+	nuget Fsharp.Core ~> 8
 
     //Server
 	nuget Fable.Remoting.Giraffe ~> 5
@@ -53,8 +53,8 @@
 	nuget Feliz ~> 2
 	
     //Build
-	nuget Fake.Core.Target
-	nuget Fake.IO.FileSystem
+	nuget Fake.Core.Target ~> 5
+	nuget Fake.IO.FileSystem ~> 5
 	nuget Farmer ~> 1
 
     //Testing

--- a/docs/recipes/upgrading/v4-to-v5.md
+++ b/docs/recipes/upgrading/v4-to-v5.md
@@ -1,0 +1,259 @@
+# How do I upgrade from SAFE v4 to v5?
+
+1. Upgrade dotnet tools to latest version:
+
+    - `dotnet tool update fable`
+    - `dotnet tool update paket`
+    - `dotnet tool update fantomas`
+    - `dotnet tool update femto`
+
+1. Remove `fantomas-tool` by running `dotnet tool uninstall fantomas-tool`
+    
+1. To upgrade to .NET 8 change the `global.json` to
+
+	```json
+	{
+	  "sdk": {
+	    "version": "8.0.0",
+	    "rollForward": "latestMinor"
+	  }
+	}
+	```
+
+    followed by updating each of your project files to target .NET 8
+
+    ```xml
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+    </PropertyGroup>
+    ```
+
+1. Upgrade .NET dependencies to latest version:
+
+	Update your `paket.dependencies` with:
+		
+	```
+	source https://api.nuget.org/v3/index.json
+	framework: net8.0
+	storage: none
+	
+	nuget Fsharp.Core
+
+    //Server
+	nuget Fable.Remoting.Giraffe ~> 5
+	nuget Saturn ~> 0
+	
+    //Client
+	nuget Fable.Core ~> 4
+	nuget Fable.Elmish ~> 4
+	nuget Fable.Elmish.React ~> 4
+	nuget Fable.Elmish.Debugger ~> 4
+	nuget Fable.Elmish.HMR ~> 7
+	nuget Fable.Remoting.Client ~> 7
+	nuget Feliz ~> 2
+	
+    //Build
+	nuget Fake.Core.Target
+	nuget Fake.IO.FileSystem
+	nuget Farmer ~> 1
+
+    //Testing
+	nuget Fable.Mocha ~> 2
+	nuget Expecto ~> 9
+	```
+	
+	- Run `dotnet paket install`
+	- Remove `Fable.React` and `Feliz.Bulma` from `src/Client/paket.references` (moved here according to @Freymaurer feedback)
+    - Run `dotnet paket update Fable.Remoting.Client`, needs to be done separately because version changes is a minor one and not major so I can't force it using only the `paket.dependencies` changes
+    - Run `dotnet paket update Fake.Core.Target`
+    - Run `dotnet paket update Fake.IO.FileSystem`
+
+1. Remove all the webpack related dependencies:
+
+	```bash
+	npm uninstall copy-webpack-plugin \
+	    css-loader \
+	    file-loader \
+	    html-webpack-plugin \
+	    mini-css-extract-plugin \
+	    sass-loader \
+	    source-map-loader \
+	    style-loader \
+	    webpack \
+	    webpack-cli \
+	    webpack-dev-server
+	```
+	
+1. Update the left over NPM dependencies:
+
+	- You can run to upgrade all at once `npx npm-check-updates -u` or if you prefer to be more conservative you can use `npx npm-check-updates -i`.
+	
+	If you use the second option, make sure to select `react`, `react-dom`, `sass`.
+	
+1. Install the new NPM dependencies
+
+	`npm install -D vite @vitejs/plugin-react tailwindcss postcss autoprefixer @types/node`
+	
+1. Delete `webpack.config.js`
+
+1. Create the file `src/Client/vite.config.mts` with the following content
+	
+	```ts
+	import { defineConfig } from "vite";
+	import react from "@vitejs/plugin-react";
+	
+	const proxyPort = process.env.SERVER_PROXY_PORT || "5000";
+	const proxyTarget = "http://localhost:" + proxyPort;
+	
+	// https://vitejs.dev/config/
+	export default defineConfig({
+	    plugins: [react()],
+	    build: {
+	        outDir: "../../deploy/public",
+	    },
+	    server: {
+	        port: 8080,
+	        proxy: {
+	            // redirect requests that start with /api/ to the server on port 5000
+	            "/api/": {
+	                target: proxyTarget,
+	                changeOrigin: true,
+	            }
+	        }
+	    }
+	});
+	```
+
+1. Overwrite `src/Client/index.html` with the following content
+	
+	```html
+	<!doctype html>
+	<html>
+	<head>
+	    <title>SAFE Template</title>
+	    <meta charset="utf-8">
+	    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+	    <link rel="icon" type="image/png" href="/favicon.png"/>
+	    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.14.0/css/all.min.css">
+	</head>
+	<body>
+	    <div id="elmish-app"></div>
+	    <!-- Polyfill for remotedev -->
+	    <script type="text/javascript">
+	        var global = global || window;
+	    </script>
+	    <script type="module" src="/output/App.js"></script>
+	</body>
+	</html>
+	```
+	
+1. Run `npx tailwindcss init -p` in `src/Client`
+1. Change `tailwind.config.js` content with
+
+	```js
+	/** @type {import('tailwindcss').Config} */
+	module.exports = {
+	    mode: "jit",
+	    content: [
+	        "./index.html",
+	        "./**/*.{fs,js,ts,jsx,tsx}",
+	    ],
+	    theme: {
+	        extend: {},
+	    },
+	    plugins: []
+	}
+	```
+
+1. In order to get VSCode Tailwind intellisense, user needs to install `Tailwind CSS Intellisense`. We also create the file `.vscode/settings.json` with the following content.
+
+	*The regex here are for Feliz style DSL, if you want to support Fable.React DSL you need to adapt the regexes*
+	
+	```json
+	{
+	    "tailwindCSS.includeLanguages": {
+	        "fsharp": "html"
+	    },
+	    "tailwindCSS.experimental.classRegex": [
+	        "\\.className\\s+\"([^\"]*)\"",
+	        ["\\.className\\s+\\[([^\\]]*)\\]", "\"([^\"]*)\""]
+	    ]
+	}
+	```
+
+1. Create a file `src/Client/index.css` with the following content
+
+	```css
+	@tailwind base;
+	@tailwind components;
+	@tailwind utilities;
+	```
+	
+1. Add the following lines at the top of `src/Client/App.fs`
+	
+	```fs
+	open Fable.Core.JsInterop
+	
+	importSideEffects "./index.css"
+	```
+
+1. Overwrite `src/Client/Index.fs` with the new version of the file (see the diff)
+
+1. Create a file `tests/Client/vite.config.mts` with the following content:
+
+	```ts
+	import { defineConfig } from "vite";
+	
+	// https://vitejs.dev/config/
+	export default defineConfig({
+	    server: {
+	        port: 8081
+	    }
+	});
+	```
+	
+1. Overwrite `tests/Client/index.html` with 
+
+	```html
+	<!DOCTYPE html>
+	<html>
+	    <head>
+	        <title>SAFE.App Client Tests</title>
+	    </head>
+	    <body>
+	        <script type="module" src="/output/Client.Tests.js"></script>
+	    </body>
+	</html>
+	```
+	
+1. Create `.fantomasignore` with the following content:
+	
+	```
+	# Ignore Fable files
+	src/Client/output/fable_modules/ 
+	```
+
+1. Remove the existing `scripts` from the `package.json`, should be `"scripts": {},` now.
+
+1. In the `build.fs` file replace the following lines:
+
+	Line 27:
+	
+	```diff
+	- "client", dotnet [ "fable"; "-o"; "output"; "-s"; "--run"; "npm"; "run"; "build" ] clientPath ]
+	+ "client", dotnet [ "fable"; "-o"; "output"; "-s"; "--run"; "npx"; "vite"; "build" ] clientPath ]
+	```
+	
+	Line 51:
+	
+	```diff
+	- "client", dotnet [ "fable"; "watch"; "-o"; "output"; "-s"; "--run"; "npm"; "run"; "start" ] clientPath ]
+	+ "client", dotnet [ "fable"; "watch"; "-o"; "output"; "-s"; "--run"; "npx"; "vite" ] clientPath ]
+	```
+	
+	Line 58:
+	
+	```diff
+	- "client", dotnet [ "fable"; "watch"; "-o"; "output"; "-s"; "--run"; "npm"; "run"; "test:live" ] clientTestsPath ]
+	+ "client", dotnet [ "fable"; "watch"; "-o"; "output"; "-s"; "--run"; "npx"; "vite" ] clientTestsPath ]
+	```

--- a/docs/recipes/upgrading/v4-to-v5.md
+++ b/docs/recipes/upgrading/v4-to-v5.md
@@ -6,7 +6,7 @@
     - `dotnet tool update paket`
     - `dotnet tool update fantomas`
     - `dotnet tool update femto`
-	- `dotnet tool restore`
+    - `dotnet tool restore`
 
 1. Remove `fantomas-tool` by running `dotnet tool uninstall fantomas-tool`
     
@@ -16,7 +16,7 @@
 	{
 	  "sdk": {
 	    "version": "8.0.0",
-	    "rollForward": "latestMinor"
+	    "rollForward": "latestMinor" 
 	  }
 	}
 	```
@@ -73,7 +73,7 @@
 
 	and install the relevant version of `node` and `npm`
 
-	**Tip**: Node Version Manage or `nvm` can be used to install and manage node/npm versions
+	**Tip**: Node Version Manager or `nvm` can be used to install and manage node/npm versions
 
 1. Remove any existing `scripts` from the `package.json` that relate to `webpack` or `webpack-dev-server`
 
@@ -180,7 +180,7 @@
 	importSideEffects "./index.css"
 	```
 
-1. In `src/Client/Index.fs` replace all view code after the `update` function with the code [here](https://github.com/SAFE-Stack/SAFE-template/blob/master/Content/default/src/Client/Index.fs)
+1. In `src/Client/Index.fs` replace all view code after the `update` function with the code [here](https://github.com/SAFE-Stack/SAFE-template/blob/master/Content/default/src/Client/Index.fs#L42-L112)
 
 1. Create a file `tests/Client/vite.config.mts` with the following content:
 

--- a/docs/recipes/upgrading/v4-to-v5.md
+++ b/docs/recipes/upgrading/v4-to-v5.md
@@ -8,6 +8,14 @@
     - `dotnet tool update femto`
     - `dotnet tool restore`
 
+1. If you want to use the same F# style the v5 SAFE Template, update your .editorconfig to include the following lines:
+
+    ```
+    [*.fs]
+    fsharp_multiline_bracket_style = stroustrup
+    fsharp_newline_before_multiline_computation_expression = false
+    ```
+
 1. Remove `fantomas-tool` by running `dotnet tool uninstall fantomas-tool`
     
 1. To upgrade to .NET 8 change the `global.json` to

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,6 +67,7 @@ nav:
 - How do I...:
   - Upgrade from V2 to V3 : 'recipes/upgrading/v2-to-v3.md'
   - Upgrade from V3 to V4 : 'recipes/upgrading/v3-to-v4.md'
+  - Upgrade from V4 to V5 : 'recipes/upgrading/v4-to-v5.md'
   - Create a new Recipe: 'recipes/template.md'
   - Build:
     - Add build automation: 'recipes/build/add-build-script.md'


### PR DESCRIPTION
WIP and needs testing and reviewing for structure

## Todo


* [x] dotnet tool restore after step 1
* [x] Display diff of src/Client/index of only the view changes as this should be the only changes
* [x] Add azure changes in Build.fs
* [x] Remove VSCode extension reference
* [x] Remove package.json scripts should be just webpack related ones?
* [x] Mention about the build.fs previously being string notation which got changed to list notation 
* [x] Add paket.references file to the Shared project with Fsharp.Core in it
* [x] package.json engines up to 18 and 20 plus instructions(links) to Node/NPM/NVM on how to upgrade
* [x] Simplified packet upgrade instructions following @isaacabraham findings with paket files - follow suggestions agreed upon below 

