### PR TITLE
direct copy of js and package management recipes where possible

### DIFF
--- a/docs/recipes/javascript/import-js-module.md
+++ b/docs/recipes/javascript/import-js-module.md
@@ -1,0 +1,101 @@
+# How do I import a JavaScript module?
+
+Sometimes you need to use a JS library directly, instead of using it through a wrapper library that makes it easy to use from F# code. In this case you need to import a module from the library.
+Here are the most common import patterns used in JS.
+
+### Default export
+
+#### Setup
+
+In most cases components use the default export syntax which is when the the component being exported from the module becomes available. For example, if the module being imported below looked something like:
+```javascript 
+// module-name
+const foo = () => "hello"
+
+export default foo
+```
+We can use the below syntax to have access to the function `foo`.
+```javascript
+import foo from 'module-name' // JS
+```
+```fsharp
+let foo = importDefault "module-name" // F#
+``` 
+
+#### Testing the import 
+
+To ensure that the import was successful you can console log the value and you should see the value in the browsers console window which you can get to by right-clicking and selecting the Inspect Element.
+```fsharp
+Browser.Dom.console.log("imported value", foo)
+```
+
+#### Example
+
+An example of this in use is how React is imported
+```javascript 
+import React from "react"
+
+// Although in the newer versions of React this is uneeded
+```
+
+### Named export 
+
+#### Setup
+
+In some cases components can use the named export syntax. In the below case "module-name" has an object/function/class that is called `bar`. By referncing it below it is brought into the current scope. 
+For example, if the module below contained something like:
+```javascript 
+export const bar (x,y) => x + y 
+```
+We can directly access the function with the below syntax 
+```javascript 
+import { bar } from "module-name" // JS
+```
+```fsharp
+let bar = import "bar" "module-name" // F#
+```
+#### Testing the import 
+
+To ensure that the import was successful you can console log the value and you should see the value in the browsers console window which you can get to by right-clicking and selecting the Inspect Element.
+```fsharp
+Browser.Dom.console.log("imported value", bar)
+```
+
+#### Example 
+
+An example of this is how React hooks are imported
+```javascript 
+import { useState } from "react"
+```
+### Entire module contents 
+
+In rare cases you may have to import an entire module's contents and provide an alias in the below case we named it myModule. You can now use dot notation to access anything that is exported from module-name. For example, if the module being imported below includes an export to a function `doAllTheAmazingThings()` you could access it like:
+```javascript
+myModule.doAllTheAmazingThings()
+```
+```javascript
+import * as myModule from 'module-name' // JS
+```
+```fsharp
+let myModule = importAll "module-name" // F#
+``` 
+
+#### Testing the import 
+
+To ensure that the import was successful you can console log the value and you should see the value in the browsers console window which you can get to by right-clicking and selecting the Inspect Element.
+```fsharp
+Browser.Dom.console.log("imported value", myModule)
+```
+
+#### Example
+
+An example of this is another way to import React 
+```javascript 
+import * as React from "react"
+
+// Uncommon since importDefault is the standard
+```
+
+### More information
+
+See the [Fable docs](https://fable.io/docs/communicate/js-from-fable.html) for more ways to import modules and use JavaScript from Fable.

--- a/docs/recipes/javascript/third-party-react-package.md
+++ b/docs/recipes/javascript/third-party-react-package.md
@@ -1,0 +1,112 @@
+To use a third-party React library in a SAFE application, you need to write an F# wrapper around it. There are two ways for doing this - using [Fable.React](https://www.nuget.org/packages/Fable.React/) or using [Feliz](https://zaid-ajaj.github.io/Feliz/).
+## Prerequisites
+
+This recipe uses the [react-d3-speedometer NPM package](https://www.npmjs.com/package/react-d3-speedometer) for demonstration purposes. [Add it to your Client](../../package-management/add-npm-package-to-client) before continuing.
+
+## Fable.React - Setup
+
+#### 1. Create a new file
+
+Create an empty file named `ReactSpeedometer.fs` in the Client project above `Index.fs` and insert the following statements at the beginning of the file.
+
+```fsharp
+module ReactSpeedometer
+
+open Fable.Core
+open Fable.Core.JsInterop
+open Fable.React
+```
+
+#### 2. Define the Props
+Prop represents the props of the React component. In this recipe, we're using [the props listed here](https://www.npmjs.com/package/react-d3-speedometer) for `react-d3-speedometer`. We model them in Fable.React using a discriminated union.
+
+```fsharp
+type Prop =
+    | Value of int
+    | MinValue of int
+    | MaxValue of int 
+    | StartColor of string
+```
+
+> One difference to note is that we use **P**ascalCase rather than **c**amelCase.
+>
+> Note that we can model any props here, both simple values and "event handler"-style ones.
+
+#### 3. Write the Component
+Add the following function to the file. Note that the last argument passed into the `ofImport` function is a list of `ReactElements` to be used as children of the react component. In this case, we are passing an empty list since the component doesn't have children.
+
+```fsharp
+let reactSpeedometer (props : Prop list) : ReactElement =
+    let propsObject = keyValueList CaseRules.LowerFirst props // converts Props to JS object
+    ofImport "default" "react-d3-speedometer" propsObject [] // import the default function/object from react-d3-speedometer
+```
+
+#### 4. Use the Component
+With all these in place, you can use the React element in your client like so:
+
+```fsharp
+open ReactSpeedometer
+
+reactSpeedometer [
+    Prop.Value 10 // Since Value is already decalred in HTMLAttr you can use Prop.Value to tell the F# compiler its of type Prop and not HTMLAttr
+    MaxValue 100
+    MinValue 0 
+    StartColor "red"
+    ]
+```
+
+## Feliz - Setup
+
+If you don't already have [Feliz](https://www.nuget.org/packages/Feliz/) installed, [add it to your client](../../ui/add-feliz).
+In the Client projects `Index.fs` add the following snippets
+
+```fsharp
+open Fable.Core.JsInterop
+```
+
+ Within the view function 
+```fsharp 
+Feliz.Interop.reactApi.createElement (importDefault "react-d3-speedometer", createObj [
+    "minValue" ==> 0
+    "maxValue" ==> 100
+    "value" ==> 10
+])
+```
+
+- `createElement` from `Feliz.ReactApi.IReactApi` takes the component you're wrapping react-d3-speedometer, the props that component takes and creates a ReactComponent we can use in F#.
+- `importDefault` from ` Fable.Core.JsInterop` is giving us access to the component and is equivalent to 
+```javascript 
+import ReactSpeedometer from "react-d3-speedometer"
+```
+The reason for using `importDefault` is the documentation for the component uses a default export "ReactSpeedometer". Please find a list of common import statetments at the end of this recipe
+
+As a quick check to ensure that the library is being imported and we have no typos you can `console.log` the following at the top within the view function 
+```fsharp
+Browser.Dom.console.log("REACT-D3-IMPORT", importDefault "react-d3-speedometer")
+```
+In the console window (which can be reached by right-clicking and selecting Insepct Element) you should see some output from the above log. 
+If nothing is being seen you may need a slightly different import statement, [please refer to this recipe](../import-js-module).
+
+- `createObj` from `Fable.Core.JsInterop` takes a sequence of `string * obj` which is a prop name and value for the component, you can find the full prop list for react-d3-speedometer [here](https://www.npmjs.com/package/react-d3-speedometer).
+- Using `==>` (short hand for `prop.custom`) to transform the sequence into a JavaScript object 
+
+```fsharp
+createObj [
+    "minValue" ==> 0
+    "maxValue" ==> 10
+]
+```
+Is equivalent to 
+```javascript 
+{ minValue: 0, maxValue: 10 }
+```
+
+That's the bare minimum needed to get going!
+
+#### Next steps for Feliz
+
+Once your component is working you may want to extract out the logic so that it can be used in multiple pages of your app.
+For a full detailed tutorial head over to [this blog post](https://www.compositional-it.com/news-blog/f-wrappers-for-react-components/)!
+
+
+

--- a/docs/recipes/package-management/add-npm-package-to-client.md
+++ b/docs/recipes/package-management/add-npm-package-to-client.md
@@ -1,0 +1,18 @@
+# How do I add an NPM package to the Client?
+
+When you want to call a JavaScript library from your Client, it is easy to import and reference it using [NPM](https://docs.npmjs.com/cli/npm).
+
+Run the following command:
+```bash
+npm install name-of-package
+```
+
+This will download the package into the solution's **node_modules** folder. 
+
+You will also see a reference to the package in the Client's **package.json** file: 
+```json
+"dependencies": {
+    "name-of-package": "^1.0.0"
+}
+``` 
+

--- a/docs/recipes/package-management/add-nuget-package-to-server.md
+++ b/docs/recipes/package-management/add-nuget-package-to-server.md
@@ -1,0 +1,19 @@
+# How do I add a NuGet package to the Server?
+You can add NuGet packages to the server to give it more capabilities. You can download a wide variety of packages from [the official NuGet site](https://nuget.org/).
+
+In this example we will add the [FsToolkit ErrorHandling package](https://www.nuget.org/packages/FsToolkit.ErrorHandling/) package.
+
+---
+
+## **I'm using the standard template** (Paket)
+
+#### 1. Add the package
+Navigate to the **root directory** of your solution and run:
+
+```bash
+dotnet paket add FsToolkit.ErrorHandling -p Server
+```
+
+This will add an entry to both the solution [paket.dependencies](https://fsprojects.github.io/Paket/dependencies-file.html) file and the Server project's [paket.reference](https://fsprojects.github.io/Paket/references-files.html) file, as well as update the lock file with the updated dependency graph.
+
+> For a detailed explanation of package management using Paket, visit the official [docs](https://fsprojects.github.io/Paket/learn-how-to-use-paket.html).

--- a/docs/recipes/package-management/add-nuget-package-to-server.md
+++ b/docs/recipes/package-management/add-nuget-package-to-server.md
@@ -3,10 +3,6 @@ You can add NuGet packages to the server to give it more capabilities. You can d
 
 In this example we will add the [FsToolkit ErrorHandling package](https://www.nuget.org/packages/FsToolkit.ErrorHandling/) package.
 
----
-
-## **I'm using the standard template** (Paket)
-
 #### 1. Add the package
 Navigate to the **root directory** of your solution and run:
 

--- a/docs/recipes/package-management/migrate-to-nuget.md
+++ b/docs/recipes/package-management/migrate-to-nuget.md
@@ -1,0 +1,72 @@
+# How do I migrate to NuGet from Paket?
+
+>  Note that the minimal template uses NuGet by default. **This recipe only applies to the full template**.
+
+Paket is a fully featured package manager that acts as an alternative to the NuGet package manager commonly used in .NET.
+
+It can help you reference libraries from NuGet, Git repositories or Http resources. It also provides precise control over your dependencies, separating direct and transitive references and capturing the exact configuration with each commit. You can find out more at the [Paket website](https://fsprojects.github.io/Paket/).
+
+For most use cases, we would recommend sticking with Paket. If, however, you are in a position where you wish to remove it and revert back to the NuGet package manager, you can easily do so with the following steps.
+
+#### 1. Remove Paket targets import from .fsproj files
+
+In every project's `.fsproj` file you will find the following line. Remove it and save.
+
+```xml
+<Import Project="..\..\.paket\Paket.Restore.targets" />
+```
+
+#### 2. Remove paket.dependencies
+
+You will find this file at the root of your solution. Remove it from your solution if included and then delete it.
+
+#### 3. Add project dependencies via NuGet
+
+Each project directory will contain a `paket.references` file. This lists all the NuGet packages that the project requires.
+
+Inside a new `ItemGroup` in the project's `.fsproj` file you will need to add an entry for each of these packages.
+
+```xml
+<ItemGroup>
+  <PackageReference Include="Azure.Core" Version="1.24" />
+  <PackageReference Include="AnotherPackage" Version="2.0.1" />
+  <!--...add entry for each package in the references file...-->
+</ItemGroup>
+```
+
+> You can find the **version** of each package in the `paket.lock` file at the root of the solution. The version number is contained in brackets next to the name of the package at the first level of indentation. For example, in this case Azure.Core is version 1.24: 
+
+```
+Azure.Core (1.24)
+    Microsoft.Bcl.AsyncInterfaces (>= 1.1.1)
+    System.Diagnostics.DiagnosticSource (>= 4.6)
+    System.Memory.Data (>= 1.0.2)
+    System.Numerics.Vectors (>= 4.5)
+    System.Text.Encodings.Web (>= 4.7.2)
+    System.Text.Json (>= 4.7.2)
+    System.Threading.Tasks.Extensions (>= 4.5.4)
+```
+
+#### 4. Remove remaining paket files
+
+Once you have added all of your dependencies to the relevant `.fsproj` files, you can remove the folowing files and folders from your solution.
+    
+**Files:**
+* `paket.lock`
+* `paket.dependencies` 
+* all of the `paket.references` files
+
+**Folders:**
+* `.paket` 
+* `paket-files` 
+
+#### 5. Remove paket tool
+
+If you open `.config/dotnet-tools.json` you will find an entry for paket. Remove it.
+
+Alternatively, run 
+
+```bash
+dotnet tool uninstall paket
+```
+at the root of your solution.

--- a/docs/recipes/package-management/sync-nuget-and-npm-packages.md
+++ b/docs/recipes/package-management/sync-nuget-and-npm-packages.md
@@ -1,0 +1,36 @@
+# How do I ensure NPM and NuGet packages stay in sync?
+SAFE Stack uses Fable bindings, which are NuGet packages that provide idiomatic and type-safe wrappers around native JavaScript APIs. These bindings often rely on third-party JavaScript libraries distributed via the NPM registry. This leads to the problem of keeping both the NPM package in sync with its corresponding NuGet F# wrapper. [Femto](https://github.com/Zaid-Ajaj/Femto) is a dotnet CLI tool that solves this issue.
+
+> For in-depth information about Femto, see [Introducing Femto](https://fable.io/blog/2019/2019-06-29-Introducing-Femto.html).
+
+---
+
+#### 1. Install Femto
+Navigate to the root folder of the solution and execute the following command:
+```powershell
+dotnet tool install femto
+```
+
+#### 2. Analyse Dependencies
+In the root directory, run the following:
+```powershell
+dotnet femto ./src/Client
+```
+
+alternatively, you can call femto directly from `./src/Client`:
+
+```powershell
+cd ./src/Client
+dotnet femto
+```
+
+This will give you a report of discrepancies between the NuGet packages and the NPM packages for the project, as well as steps to take in order to resolve them.
+
+#### 3. Resolve Dependencies
+To sync your NPM dependencies with your NuGet dependencies, you can either manually follow the steps returned by *step 2*, or resolve them automatically using the following command:
+```powershell
+dotnet femto ./src/Client --resolve
+```
+
+## Done!
+Keeping your NPM dependencies in sync with your NuGet packages is now as easy as repeating step 3. Of course, you can instead repeat the step 2 and resolve packages manually, too.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,6 +71,14 @@ nav:
   - Create a new Recipe: 'recipes/template.md'
   - UI:
     - Add daisyUI support: 'recipes/ui/add-daisyui.md'
+  - JavaScript:
+      - Import a JavaScript module: 'recipes/javascript/import-js-module.md'
+      - Add Support for a Third Party React Library: 'recipes/javascript/third-party-react-package.md'
+  - Package Management:
+      - Add an NPM package to the Client: 'recipes/package-management/add-npm-package-to-client.md'
+      - Add a NuGet package to the Server: 'recipes/package-management/add-nuget-package-to-server.md'
+      - Migrate to NuGet from Paket: 'recipes/package-management/migrate-to-nuget.md'
+      - Sync NuGet and NPM Packages: 'recipes/package-management/sync-nuget-and-npm-packages.md'
 - FAQs:
   - Moving from dev to prod : 'faq-build.md'
   - Troubleshooting : 'faq-troubleshooting.md'
@@ -129,4 +137,3 @@ nav:
     - Migrate to Paket from NuGet: 'v4-recipes/package-management/migrate-to-paket.md'
     - Migrate to NuGet from Paket: 'v4-recipes/package-management/migrate-to-nuget.md'
     - Sync NuGet and NPM Packages: 'v4-recipes/package-management/sync-nuget-and-npm-packages.md'
-


### PR DESCRIPTION
Copy all recipes that did not need changing from V4 recipe folder to recipe folder; following are skipped:

* Add a NuGet package to the client: recipe was not complete, will rewrite
* Migrate to Paket from Nuget: recipe only applies to minimal template