### PR TITLE
'dotnet new --install' is deprecated

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -21,7 +21,7 @@ You'll also want an IDE to create F# applications. We recommend one of the follo
 
 1. Open a command prompt
 1. Create a new directory on your machine and navigate into it
-1. Enter `dotnet new -i SAFE.Template` to install the [SAFE project template](template-overview.md) (*only required once *)
+1. Enter `dotnet new install SAFE.Template` to install the [SAFE project template](template-overview.md) (*only required once *)
 1. Enter `dotnet new SAFE` to create a new SAFE project
 1. Enter `dotnet tool restore` to install local tools like Fable.
 1. Enter `dotnet run` to build and run the app


### PR DESCRIPTION
Running ` dotnet new -i SAFE.Template` gives a warning:
```
Warning: use of 'dotnet new --install' is deprecated. Use 'dotnet new install' instead.
For more information, run:
   dotnet new install -h
```

Proposing to update the docs to use latest syntax.