### PR TITLE
Move "add feliz" recipe from v4 to current

### DIFF
--- a/docs/recipes/ui/add-feliz.md
+++ b/docs/recipes/ui/add-feliz.md
@@ -2,7 +2,7 @@
 [Feliz](https://github.com/Zaid-Ajaj/Feliz) is a wrapper for the base [React](https://reactjs.org/) DSL library that emphasises consistency, lightweight formatting, discoverable attributes and full type-safety. The default SAFE Template already uses Feliz.
 
 ### Using Feliz
-1. [Add Feliz to your project](./../package-management/add-nuget-package-to-client.md)
+1. [Add Feliz to your project](./../../v4-recipes//package-management/add-nuget-package-to-client.md)
 1. Start using Feliz in your code.
 
 ```fsharp

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,6 +74,7 @@ nav:
           - Package my SAFE app for deployment: "recipes/build/bundle-app.md"
       - UI:
           - Add daisyUI support: "recipes/ui/add-daisyui.md"
+          - Add Feliz support: "recipes/ui/add-feliz.md"
           - Add FontAwesome support: "recipes/ui/add-fontawesome.md"
       - Storage:
           - Quickly add a database: "recipes/storage/use-litedb.md"
@@ -139,7 +140,6 @@ nav:
           - Remove Bulma: "v4-recipes/ui/remove-bulma.md"
           - Add Tailwind support: "v4-recipes/ui/add-tailwind.md"
           - Add daisyUI support: "v4-recipes/ui/add-daisyui.md"
-          - Add Feliz support: "v4-recipes/ui/add-feliz.md"
           - Migrate from a CDN stylesheet to an NPM package: "v4-recipes/ui/cdn-to-npm.md"
           - Add routing with state shared between pages: "v4-recipes/ui/add-routing.md"
           - Add routing with separate models per page: "v4-recipes/ui/add-routing-with-separate-models.md"


### PR DESCRIPTION
No changes needed but I had to change a link to point at an old version of a recipe  since the current version doesn't exist (prompted by a MkDocs warning as below).

We will need to do a pass at the end to ensure that all the links are pointing to the correct version of the docs.

The MkDocs warning in question, quite helpful - now fixed by pointing to old docs.
```
WARNING  -  Documentation file 'recipes/ui/add-feliz.md' contains a link to
            'recipes/package-management/add-nuget-package-to-client.md' which is not 
            found in the documentation files.
```