### PR TITLE
Bugfix for Saturn to Giraffe guide manifesting as issue in bundled app

### DIFF
--- a/docs/recipes/client-server/saturn-to-giraffe.md
+++ b/docs/recipes/client-server/saturn-to-giraffe.md
@@ -46,7 +46,7 @@ and replace it with this
 ```fsharp
 let configureApp (app : IApplicationBuilder) =
     app
-        .UseStaticFiles()
+        .UseFileServer()
         .UseGiraffe webApp
 
 let configureServices (services : IServiceCollection) =


### PR DESCRIPTION
Issue #362 

This fix swaps out `app.UseStaticFiles()` for `app.UseFileServer()`.

This effectively adds the behaviour of `app.UseDefaultFiles()` which will serve up `/index.html` upon request to `/`.

More info:
https://learn.microsoft.com/en-us/aspnet/core/fundamentals/static-files?view=aspnetcore-8.0#usefileserver-for-default-documents