### PR TITLE
Add fix to FAQ for .net9 breaking dotnet watch

### DIFF
--- a/docs/faq/faq-troubleshooting.md
+++ b/docs/faq/faq-troubleshooting.md
@@ -1,3 +1,26 @@
+### Dotnet watch cannot open '.fsproj' project
+
+At the time of writing, the release of .net9.0 has precipitated an issue where `dotnet watch` fails:
+
+```sh
+dotnet watch ❌ System.InvalidOperationException: Cannot open project 'D:\code\TodoService\src\app\app.fsproj' because the file extension '.fsproj' is not associated with a language.
+```
+
+Besides deferring upgrading `.net`, [it is possible to fix this issue](https://github.com/dotnet/sdk/issues/44908#issuecomment-2483510197) by modifying the arguments passed to `dotnet` when running the `Server` project in `Build.fs`:
+
+```fs
+Target.create "Run" (fun _ ->
+    run dotnet [ "restore"; "Application.sln" ] "."
+    run dotnet [ "build" ] sharedPath
+
+    [
+                                                          // `--no-hot-reload` applied fix for dotnet cannot open project
+        "server", dotnet [ "watch"; "run"; "--no-restore" ; "--no-hot-reload"] serverPath
+        "client", dotnet [ "fable"; "watch"; "-o"; "output"; "-s"; "--run"; "npx"; "vite" ] clientPath
+    ]
+    |> runParallel)
+```
+
 ### Run error due to node/npm version
 
 You may receive an error when trying to run the app, e.g. the current version might require `{"node":"~18 || ~20","npm":"~9 || ~10"}` but your locally installed versions are different. Ideally we'd like to install different versions side-by-side, which we can do using [Node Version Manager](https://www.freecodecamp.org/news/node-version-manager-nvm-install-guide/).


### PR DESCRIPTION
# Issue

[Upgrading to `.net9` has broken the build process for the SAFE stack by default](https://github.com/dotnet/sdk/issues/44908)

# What does this pull request address

This pull request adds another section to the FAQ section troubleshoot page [which suggests a potential fix](https://github.com/dotnet/sdk/issues/44908#issuecomment-2483510197) should this issue occur in the future with major dotnet releases

# How does this pull request address this

Provides the additional command to be passed to `Build.fs` to allow continued development (without hot-code-reloading stopping despite the name of the argument as is discussed the above referenced issue thread).

```fs
Target.create "Run" (fun _ ->
    run dotnet [ "restore"; "Application.sln" ] "."
    run dotnet [ "build" ] sharedPath

    [
        "server", dotnet [ "watch"; "run"; "--no-restore" ; "--no-hot-reload"] serverPath
        "client", dotnet [ "fable"; "watch"; "-o"; "output"; "-s"; "--run"; "npx"; "vite" ] clientPath
    ]
    |> runParallel)
```
